### PR TITLE
Add Ollama control to start panel and refine model tags

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -264,13 +264,17 @@ function Start-Ollama {
     }
 
     Set-ActionMessage "Starting Ollama..." "Yellow"
-    Start-Process -FilePath "ollama" -ArgumentList "serve" -WindowStyle Hidden
-    Start-Sleep -Seconds 1
+    try {
+        Start-Process -FilePath "ollama" -ArgumentList "serve" -WindowStyle Hidden -ErrorAction Stop
+        Start-Sleep -Seconds 1
 
-    if (Test-OllamaRunning -TimeoutSec 3) {
-        Set-ActionMessage "Ollama started at $ollamaUrl" "Green"
-    } else {
-        Set-ActionMessage "Started, API warming up..." "Yellow"
+        if (Test-OllamaRunning -TimeoutSec 3) {
+            Set-ActionMessage "Ollama started at $ollamaUrl" "Green"
+        } else {
+            Set-ActionMessage "Started, API warming up..." "Yellow"
+        }
+    } catch {
+        Set-ActionMessage "Failed to start Ollama: $_" "Red"
     }
 }
 

--- a/settings.py
+++ b/settings.py
@@ -140,7 +140,7 @@ RECOMMENDED_MODELS: dict[str, ModelInfo] = {
         "description": "MoE (30B/3B active), strong reasoning - excellent for architect",
         "tags": ["architect", "continuity", "interviewer", "suggestion"],
     },
-    # Quality 7 reasoning: architect, continuity, interviewer. No suggestion (Q7 limit).
+    # Quality 7 reasoning: architect, continuity, interviewer. No suggestion (reasoning focus).
     "huihui_ai/qwen3-abliterated:8b": {
         "name": "Qwen3 8B Abliterated",
         "size_gb": 5,


### PR DESCRIPTION
## Summary
- Add **[7] Ollama** option to control panel for starting/checking Ollama status
- Show Ollama status in panel header with API URL from settings.json
- Refine model tags based on quality thresholds and model specialization

## Control Panel Changes
- New `Start-Ollama` function with API-based health checks (not process-based)
- Reads `ollama_url` from settings.json for correct endpoint
- Supports both Windows service and standalone `ollama serve`
- Fast 1s timeout for status display, 3s for startup verification

## Model Tag Refinements
| Quality | Roles Allowed |
|---------|---------------|
| 8+ | writer, editor (creative prose) |
| 8+ | architect (complex planning) |
| 7+ | continuity, suggestion |
| 5+ | interviewer |
| 3+ | validator |

- Creative models (Celeste, Dark Champion): writer, editor, suggestion, interviewer (no architect)
- Reasoning models (Qwen3): architect, continuity, interviewer (no writer/editor)
- 70B+ models: All roles (size compensates for specialization)

## Test plan
- [ ] Run `start.bat` and verify panel shows Ollama status
- [ ] Press [7] when Ollama stopped - verify it starts
- [ ] Press [7] when Ollama running - verify "already running" message
- [ ] Verify model auto-selection respects new tag assignments

🤖 Generated with [Claude Code](https://claude.com/claude-code)