### PR TITLE
feat: Add WP1/WP2 settings to Settings UI (#201)

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -50,6 +50,14 @@ class AgentRoleInfo(TypedDict):
     description: str
 
 
+# Temperature decay curve options for world quality refinement
+REFINEMENT_TEMP_DECAY_CURVES: dict[str, str] = {
+    "linear": "Linear",
+    "exponential": "Exponential",
+    "step": "Step",
+}
+
+
 # Agent role definitions
 AGENT_ROLES: dict[str, AgentRoleInfo] = {
     "interviewer": {
@@ -655,10 +663,10 @@ class Settings:
                 raise ValueError(f"{temp_name} must be between 0.0 and 2.0, got {temp_value}")
 
         # Validate dynamic temperature decay curve
-        valid_decay_curves = ["linear", "exponential", "step"]
-        if self.world_quality_refinement_temp_decay not in valid_decay_curves:
+        if self.world_quality_refinement_temp_decay not in REFINEMENT_TEMP_DECAY_CURVES:
             raise ValueError(
-                f"world_quality_refinement_temp_decay must be one of {valid_decay_curves}, "
+                f"world_quality_refinement_temp_decay must be one of "
+                f"{list(REFINEMENT_TEMP_DECAY_CURVES.keys())}, "
                 f"got {self.world_quality_refinement_temp_decay}"
             )
 

--- a/tests/component/test_settings_page.py
+++ b/tests/component/test_settings_page.py
@@ -235,10 +235,13 @@ class TestSettingsPage:
 
         page = page_ref[0]
 
-        # Change some values
+        # Capture original values for test isolation
         original_failure_threshold = test_services.settings.circuit_breaker_failure_threshold
+        original_retry_temp = test_services.settings.retry_temp_increase
+        original_min_iterations = test_services.settings.world_quality_early_stopping_min_iterations
         new_failure_threshold = 10
 
+        # Change some values
         page._circuit_breaker_failure_threshold_input.value = new_failure_threshold
         page._retry_temp_increase_input.value = 0.25
         page._early_stopping_min_iterations_input.value = 3
@@ -251,8 +254,10 @@ class TestSettingsPage:
         assert test_services.settings.retry_temp_increase == 0.25
         assert test_services.settings.world_quality_early_stopping_min_iterations == 3
 
-        # Restore original value for test isolation
+        # Restore original values for test isolation
         test_services.settings.circuit_breaker_failure_threshold = original_failure_threshold
+        test_services.settings.retry_temp_increase = original_retry_temp
+        test_services.settings.world_quality_early_stopping_min_iterations = original_min_iterations
 
     async def test_settings_snapshot_includes_advanced_llm_settings(
         self, user: User, test_app_state, test_services


### PR DESCRIPTION
## Summary
- Add UI controls for advanced LLM settings (WP1/WP2) to the Settings page
- Settings were previously only configurable via `settings.json`, now exposed in the web UI
- Grouped in an expandable "Advanced LLM Settings" section with 5 subsections

## Changes
**New UI Controls:**
- **Circuit Breaker**: enabled switch, failure threshold (1-20), success threshold (1-10), timeout (10-600s)
- **Retry Strategy**: temperature increase (0.0-1.0), simplify on attempt (2-10)
- **Duplicate Detection**: enabled switch, similarity threshold (0.5-1.0), embedding model select
- **Refinement Temperature**: start temp, end temp, decay curve (linear/exponential/step)
- **Early Stopping**: min iterations (1-10), variance tolerance (0.0-2.0)

**Code Changes:**
- `src/ui/pages/settings.py`: Added `_build_advanced_llm_section()` method and updated save/snapshot/restore/refresh methods
- `tests/component/test_settings_page.py`: 9 new component tests for the settings page

## Test plan
- [x] All 9 new component tests pass
- [x] All 182 existing settings unit tests pass
- [x] `ruff format` and `ruff check` pass
- [x] Pre-commit and pre-push hooks pass
- [ ] Manual verification: Start app, navigate to Settings, verify Advanced LLM Settings section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)