### PR TITLE
feat: improve settings UI for relationship_minimums and circular types

### DIFF
--- a/src/ui/pages/settings/_advanced.py
+++ b/src/ui/pages/settings/_advanced.py
@@ -602,10 +602,17 @@ def build_relationship_validation_section(page: SettingsPage) -> None:
                     def add_circular_type() -> None:
                         """Add a new circular relationship type from the input field."""
                         new_type = page._new_circular_type_input.value.strip().lower()
-                        if new_type and new_type not in page.settings.circular_relationship_types:
-                            page.settings.circular_relationship_types.append(new_type)
+                        if not new_type:
+                            logger.debug("Skipped adding circular relationship type: empty input")
+                            return
+                        if new_type in page.settings.circular_relationship_types:
+                            logger.debug("Circular relationship type already present: %s", new_type)
                             page._new_circular_type_input.value = ""
-                            _build_circular_type_chips(page)
+                            return
+                        page.settings.circular_relationship_types.append(new_type)
+                        logger.info("Added circular relationship type: %s", new_type)
+                        page._new_circular_type_input.value = ""
+                        _build_circular_type_chips(page)
 
                     ui.button(icon="add", on_click=add_circular_type).props(
                         "flat dense round"


### PR DESCRIPTION
## Summary

- Make `relationship_minimums` fully editable with number inputs per entity type/role combination (was read-only with "edit JSON" note)
- Replace `circular_relationship_types` text input with chip/tag editor for better UX (add/remove types with visual chips)
- Add proper persistence for `relationship_minimums` (snapshot/restore)
- Rebuild circular type chips on settings restore/undo

## Motivation

Per CLAUDE.md: "Settings must have UI. Any new settings added to `src/settings.py` MUST be exposed in the Settings page UI."

The `relationship_minimums` setting was displayed as read-only with instructions to "edit settings.json directly" which violated this guideline.

The `circular_relationship_types` was a comma-separated text input which is poor UX for a list of tags.

## Test plan

- [ ] Open Settings page
- [ ] Verify relationship minimums section has editable number inputs for each entity type/role
- [ ] Verify circular check types shows chips that can be removed with X button
- [ ] Verify new types can be added via the input + add button
- [ ] Verify Save Settings persists changes
- [ ] Verify Undo/Redo works for both settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)