### PR TITLE
fix: Improve settings UI - dropdown for circular types, expand sections

### DIFF
--- a/src/ui/pages/settings/_advanced.py
+++ b/src/ui/pages/settings/_advanced.py
@@ -860,6 +860,10 @@ def refresh_from_settings(page: SettingsPage) -> None:
     # Update circular types multi-select from settings
     if hasattr(page, "_circular_types_select"):
         logger.debug("Updating circular types select from settings")
+        # Update options to include any types from restored settings
+        page._circular_types_select.options = _get_circular_type_options(
+            settings.circular_relationship_types
+        )
         page._circular_types_select.value = list(settings.circular_relationship_types)
 
     # Calendar and temporal validation settings


### PR DESCRIPTION
## Summary

Improves the Settings page UX based on user feedback:

1. **Replace free-form chip editor with multi-select dropdown** for circular relationship types
   - Uses known types from `RELATION_CONFLICT_MAPPING` (~30 relationship types)
   - Prevents typos and shows available options clearly
   - Uses NiceGUI's `use-chips` prop for nice visual display of selected items

2. **Expand Advanced LLM sections by default** - they were collapsed and "looking bad"
   - Circuit Breaker
   - Retry Strategy
   - Duplicate Detection
   - Refinement Temperature
   - Early Stopping

3. **Expand Relationship Minimums section by default**

## Before/After

| Before | After |
|--------|-------|
| Collapsed sections, need to click to expand | All sections visible by default |
| Free-form text input for circular types (typo-prone) | Multi-select dropdown with known types |

## Test plan

- [ ] Open Settings page, verify Advanced LLM sections are expanded
- [ ] Verify Relationship Minimums section is expanded
- [ ] Verify circular check types shows multi-select dropdown
- [ ] Select/deselect relationship types and verify they persist
- [ ] Run `pytest tests/unit/test_settings.py` - all 201 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)