### PR TITLE
feat: add diagnostic scripts for refinement loop analysis (#223)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,9 @@ omit = [
     "scripts/audit_exceptions.py",
     "scripts/check_deps.py",
     "scripts/check_file_size.py",
+    "scripts/evaluate_ab_prompts.py",
+    "scripts/evaluate_judge_consistency.py",
+    "scripts/evaluate_refinement.py",
     "scripts/healthcheck.py",
 ]
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,193 @@
+# Scripts
+
+Standalone utility scripts for development, diagnostics, and operations. These are **not** part of the main application and are excluded from test coverage requirements.
+
+## Quick Reference
+
+| Script                            | Purpose                          | When to use                                     |
+| --------------------------------- | -------------------------------- | ----------------------------------------------- |
+| `evaluate_judge_consistency.py`   | Measure judge scoring variance   | First step when diagnosing refinement failures  |
+| `evaluate_refinement.py`          | Full refinement loop instrumentation | Main diagnostic for refinement loop issues  |
+| `evaluate_ab_prompts.py`          | A/B test prompt variants         | After identifying prompt-related problems       |
+| `control_panel.py`                | Desktop GUI for app management   | Running Story Factory on desktop                |
+| `start.ps1`                       | PowerShell control panel         | Running Story Factory on Windows                |
+| `healthcheck.py`                  | Verify environment setup         | After install or when things break              |
+| `check_deps.py`                   | Check/install dependencies       | After updating pyproject.toml                   |
+| `check_file_size.py`              | Enforce max file length          | Pre-commit hook (automatic)                     |
+| `audit_exceptions.py`             | Audit exception handling patterns | Code quality review                            |
+
+---
+
+## Diagnostic Scripts (Issue #223)
+
+Three scripts for investigating world quality refinement loop failures. They instrument the create-judge-refine pipeline to pinpoint whether problems originate in the judge, the refiner, or the prompts.
+
+**Prerequisites:**
+- Ollama running locally with a model pulled (e.g. `huihui_ai/dolphin3-abliterated:8b`)
+- `src/settings.json` exists with valid config (copy from `src/settings.example.json`)
+
+**Execution order matters** -- run them in the order listed below. Each script's results inform whether the next script is needed.
+
+### Step 1: `evaluate_judge_consistency.py`
+
+Measures judge scoring variance by calling the judge N times on the **same frozen entity**. Determines if the judge is noisy (unreliable) or consistent.
+
+```bash
+python scripts/evaluate_judge_consistency.py [options]
+  --entity-types faction,concept  # Comma-separated (default: all 6)
+  --judge-calls 5                 # Calls per entity (default: 5)
+  --output results.json           # Output path (default: output/diagnostics/<timestamp>_judge.json)
+  --verbose                       # Print per-call scores
+```
+
+**Example (quick smoke test):**
+
+```bash
+python scripts/evaluate_judge_consistency.py --entity-types faction --judge-calls 3 --verbose
+```
+
+**Output interpretation:**
+
+| Verdict                    | Meaning                | Next step                                                                    |
+| -------------------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| `CONSISTENT` (std < 0.2)  | Judge is reliable      | Proceed to Step 2                                                            |
+| `BORDERLINE` (std 0.2-0.5) | Some noise, not critical | May benefit from multi-call averaging                                      |
+| `NOISY` (std > 0.5)       | Judge is unreliable    | Fix judge first (lower temperature, structured output, multi-call averaging) |
+
+Key fields in the JSON output:
+- `results[].per_dimension_stats` -- std per scoring dimension (the key metric)
+- `results[].verdict` -- per-entity-type verdict
+- `results[].feedback_similarity` -- Jaccard overlap between feedback strings (low = inconsistent text)
+
+### Step 2: `evaluate_refinement.py`
+
+Runs the full create-judge-refine loop with instrumentation, capturing entity snapshots, scores, feedback, and timing at every iteration.
+
+```bash
+python scripts/evaluate_refinement.py [options]
+  --entity-types faction,concept  # Comma-separated (default: all 6)
+  --count-per-type 3              # Entities per type (default: 3)
+  --output results.json           # Output path (default: output/diagnostics/<timestamp>.json)
+  --verbose                       # Print per-iteration scores
+```
+
+**Example (quick smoke test):**
+
+```bash
+python scripts/evaluate_refinement.py --entity-types faction --count-per-type 1 --verbose
+```
+
+**Output interpretation:**
+
+| Metric                  | Where in JSON                                  | Healthy    | Broken           |
+| ----------------------- | ---------------------------------------------- | ---------- | ---------------- |
+| Pass rate               | `summary.pass_rate_by_type`                    | >50%       | <30%             |
+| Score improvement/iter  | `summary.avg_score_improvement_per_iteration`  | >0.3       | <0.1             |
+| Description diff ratio  | `summary.avg_description_diff_ratio`           | 0.15-0.40  | <0.10 or >0.50   |
+| Plateau rate            | `summary.plateau_rate`                         | <30%       | >60%             |
+| Regression rate         | `summary.regression_rate`                      | <15%       | >30%             |
+| Feedback specificity    | `summary.avg_feedback_specificity`             | >0.15      | <0.05            |
+
+**Decision tree:**
+
+1. **diff_ratio < 0.10** -- Refiner makes cosmetic changes only. Fix: improve refine prompts.
+2. **diff_ratio > 0.30 but score improvement < 0.2** -- Refiner changes substance but judge doesn't reward it. Fix: differentiate judge prompt.
+3. **Feedback specificity < 0.05** -- Judge gives generic feedback the refiner can't act on. Fix: improve judge prompt.
+4. **Specificity > 0.10 but no improvement** -- Good feedback, refiner ignores it. Fix: improve refine prompts to use feedback.
+5. **Plateau rate > 60%** -- Iterations wasted, scores don't move. Likely cause: threshold/calibration conflict.
+6. **Regression rate > 30%** -- Refinement makes things worse. Likely cause: temperature decay too aggressive.
+
+### Step 3: `evaluate_ab_prompts.py`
+
+A/B tests current production prompts (A) vs improved variants (B) on the same seed entities. Run this if Step 2 points to prompt problems.
+
+```bash
+python scripts/evaluate_ab_prompts.py [options]
+  --entity-types faction,concept  # Comma-separated (default: character,faction,concept,item,location)
+  --count-per-type 3              # Seeds per type (default: 3)
+  --output results.json           # Output path (default: output/diagnostics/<timestamp>_ab.json)
+  --verbose                       # Print per-entity scores
+```
+
+**What the improved prompts change:**
+- Use actual quality threshold from config instead of hardcoded "need 9+"
+- Include per-dimension numeric scores
+- Add actionable improvement instructions derived from low-scoring dimensions
+- Include judge feedback more prominently
+
+**Output interpretation:**
+
+| `avg_delta_ab` | Meaning                            | Action                                  |
+| -------------- | ---------------------------------- | --------------------------------------- |
+| > 0.5          | Improved prompts help significantly | Implement prompt changes               |
+| 0.2 - 0.5     | Modest improvement                 | Consider implementing                   |
+| -0.2 - 0.2    | No significant difference          | Prompt changes alone won't fix this     |
+| < -0.2         | Current prompts are better         | Investigate other causes                |
+
+### Diagnostic Output Files
+
+All output goes to `output/diagnostics/`:
+- `judge_consistency_<timestamp>.json`
+- `refinement_<timestamp>.json`
+- `ab_prompts_<timestamp>.json`
+
+---
+
+## Operations Scripts
+
+### `control_panel.py`
+
+Native desktop GUI (CustomTkinter) for managing the Story Factory application. Start/stop the server, monitor logs, open the browser.
+
+```bash
+python scripts/control_panel.py
+```
+
+Requires `customtkinter` (optional dependency, not installed by default).
+
+### `start.ps1`
+
+PowerShell terminal-based control panel for Windows. Same functionality as `control_panel.py` but runs in the terminal.
+
+```powershell
+.\scripts\start.ps1
+```
+
+Menu options: Start, Stop, Restart, Open Browser, Clear Logs, Start Ollama, Quit.
+
+### `healthcheck.py`
+
+Verifies the environment is correctly set up: Python version, required packages, Ollama connectivity, output directories.
+
+```bash
+python scripts/healthcheck.py
+```
+
+### `check_deps.py`
+
+Compares installed package versions against `pyproject.toml` requirements. Optionally auto-installs missing or outdated packages.
+
+```bash
+python scripts/check_deps.py              # Check only
+python scripts/check_deps.py --auto-install  # Check and fix
+```
+
+---
+
+## Development Scripts
+
+### `check_file_size.py`
+
+Pre-commit hook that enforces the 1000-line maximum for Python files in `src/`. Runs automatically via pre-commit; not typically invoked manually.
+
+```bash
+python scripts/check_file_size.py [files...]
+```
+
+### `audit_exceptions.py`
+
+Scans the codebase for exception handling patterns. Reports broad `except Exception` catches, missing logging in handlers, and missing `from` clauses on re-raises.
+
+```bash
+python scripts/audit_exceptions.py
+```

--- a/scripts/evaluate_ab_prompts.py
+++ b/scripts/evaluate_ab_prompts.py
@@ -1,0 +1,914 @@
+#!/usr/bin/env python3
+"""A/B test current vs improved refine prompts on the same seed entities.
+
+Tests current refine prompts vs improved variants to determine whether
+prompt changes can improve refinement effectiveness.
+
+Protocol:
+1. Generate N seed entities per type
+2. Judge each seed -> baseline score
+3. Refine with CURRENT production prompt -> judge -> score A
+4. Refine with IMPROVED prompt variant -> judge -> score B
+5. Compare A vs B
+
+Usage:
+    python scripts/evaluate_ab_prompts.py [options]
+      --entity-types faction,concept  (default: faction, concept, item, location)
+      --count-per-type 3              (default: 3)
+      --output results.json           (default: output/diagnostics/<timestamp>_ab.json)
+      --verbose
+"""
+
+import argparse
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.evaluate_refinement import (
+    ALL_ENTITY_TYPES,
+    make_canonical_brief,
+    make_story_state,
+)
+from src.memory.story_state import (
+    Character,
+    Concept,
+    Faction,
+    Item,
+    Location,
+    StoryState,
+)
+from src.memory.world_quality import (
+    CharacterQualityScores,
+    ConceptQualityScores,
+    FactionQualityScores,
+    ItemQualityScores,
+    LocationQualityScores,
+)
+from src.services import ServiceContainer
+from src.services.llm_client import generate_structured
+from src.services.world_quality_service import WorldQualityService
+from src.settings import Settings
+from src.utils.exceptions import StoryFactoryError
+
+logger = logging.getLogger(__name__)
+
+# Default: test the 4 dict-based entity types (Type B in the plan) plus character (Type A)
+DEFAULT_AB_TYPES = ["character", "faction", "concept", "item", "location"]
+
+
+def _format_improvements(
+    improvement_focus: list[str], fallback: str = "- Minor enhancements only"
+) -> str:
+    """Format improvement focus items as a newline-separated list.
+
+    Args:
+        improvement_focus: List of improvement instruction strings.
+        fallback: Text to use when no improvements are needed.
+
+    Returns:
+        Formatted string with one improvement per line, prefixed with "- ".
+    """
+    if not improvement_focus:
+        return fallback
+    return "\n".join(f"- {imp}" for imp in improvement_focus)
+
+
+def improved_refine_character(
+    svc: WorldQualityService,
+    character: Character,
+    scores: CharacterQualityScores,
+    story_state: StoryState,
+    temperature: float,
+) -> Character:
+    """Improved character refinement prompt (Type A fix).
+
+    Changes vs production:
+    - Adds numeric scores per dimension
+    - Adds explicit threshold target matching actual config (not 9+)
+    - Includes judge feedback more prominently
+    - Derives specific improvement instructions from dimension scores
+    """
+    brief = story_state.brief
+    config = svc.get_config()
+    threshold = config.quality_threshold
+
+    # Build actionable improvement instructions from scores (like Type B does)
+    improvement_focus = []
+    if scores.depth < threshold:
+        improvement_focus.append(
+            f"DEPTH ({scores.depth}/10): Add more internal contradictions, hidden motivations, "
+            f"or psychological layers"
+        )
+    if scores.goals < threshold:
+        improvement_focus.append(
+            f"GOALS ({scores.goals}/10): Clarify what the character wants vs what they need; "
+            f"make goals more story-relevant"
+        )
+    if scores.flaws < threshold:
+        improvement_focus.append(
+            f"FLAWS ({scores.flaws}/10): Add meaningful vulnerabilities that drive specific "
+            f"conflicts, not just surface-level weaknesses"
+        )
+    if scores.uniqueness < threshold:
+        improvement_focus.append(
+            f"UNIQUENESS ({scores.uniqueness}/10): Differentiate from genre archetypes with "
+            f"unexpected traits, background, or worldview"
+        )
+    if scores.arc_potential < threshold:
+        improvement_focus.append(
+            f"ARC POTENTIAL ({scores.arc_potential}/10): Create clearer transformation paths "
+            f"with specific catalysts for change"
+        )
+
+    prompt = f"""TASK: Improve this character to meet quality threshold {threshold}/10 average.
+
+ORIGINAL CHARACTER:
+Name: {character.name}
+Role: {character.role}
+Description: {character.description}
+Traits: {", ".join(character.personality_traits)}
+Goals: {", ".join(character.goals)}
+Arc Notes: {character.arc_notes}
+
+CURRENT SCORES (target: {threshold}+ average, currently {scores.average:.1f}):
+- Depth: {scores.depth}/10
+- Goals: {scores.goals}/10
+- Flaws: {scores.flaws}/10
+- Uniqueness: {scores.uniqueness}/10
+- Arc Potential: {scores.arc_potential}/10
+
+JUDGE'S SPECIFIC FEEDBACK (address each point):
+{scores.feedback}
+
+PRIORITY IMPROVEMENTS (focus on these dimensions):
+{_format_improvements(improvement_focus, "- All dimensions above threshold, make minor enhancements")}
+
+REQUIREMENTS:
+1. Keep the name "{character.name}" and role "{character.role}"
+2. Make SUBSTANTIAL changes to description, traits, goals, and arc_notes
+3. Do NOT just rephrase existing content - add NEW details and complexity
+4. Write all text in {brief.language if brief else "English"}"""
+
+    model = svc._get_creator_model(entity_type="character")
+    return generate_structured(
+        settings=svc.settings,
+        model=model,
+        prompt=prompt,
+        response_model=Character,
+        temperature=temperature,
+    )
+
+
+def improved_refine_faction(
+    svc: WorldQualityService,
+    faction: dict[str, Any],
+    scores: FactionQualityScores,
+    story_state: StoryState,
+    temperature: float,
+) -> dict[str, Any]:
+    """Improved faction refinement prompt (Type B fix).
+
+    Changes vs production:
+    - Uses actual quality threshold instead of "need 9+"
+    - Includes judge feedback more prominently with action items
+    - Derives improvement instructions from feedback text
+    """
+    brief = story_state.brief
+    config = svc.get_config()
+    threshold = config.quality_threshold
+
+    improvement_focus = []
+    if scores.coherence < threshold:
+        improvement_focus.append(
+            f"COHERENCE ({scores.coherence}/10): Strengthen internal logic, add clearer "
+            f"organizational structure and rules"
+        )
+    if scores.influence < threshold:
+        improvement_focus.append(
+            f"INFLUENCE ({scores.influence}/10): Expand world impact with specific power "
+            f"mechanisms and territorial/political reach"
+        )
+    if scores.conflict_potential < threshold:
+        improvement_focus.append(
+            f"CONFLICT ({scores.conflict_potential}/10): Add internal tensions, rival "
+            f"relationships, and specific friction points"
+        )
+    if scores.distinctiveness < threshold:
+        improvement_focus.append(
+            f"DISTINCTIVENESS ({scores.distinctiveness}/10): Add unique rituals, symbols, "
+            f"jargon, or cultural practices that set this faction apart"
+        )
+
+    prompt = f"""TASK: Improve this faction to meet quality threshold {threshold}/10 average.
+Current average: {scores.average:.1f}/10.
+
+ORIGINAL FACTION:
+Name: {faction.get("name", "Unknown")}
+Description: {faction.get("description", "")}
+Leader: {faction.get("leader", "Unknown")}
+Goals: {", ".join(faction.get("goals", []))}
+Values: {", ".join(faction.get("values", []))}
+
+CURRENT SCORES (target: {threshold}+ average):
+- Coherence: {scores.coherence}/10
+- Influence: {scores.influence}/10
+- Conflict Potential: {scores.conflict_potential}/10
+- Distinctiveness: {scores.distinctiveness}/10
+
+JUDGE'S SPECIFIC FEEDBACK (address each point):
+{scores.feedback}
+
+PRIORITY IMPROVEMENTS:
+{_format_improvements(improvement_focus, "- All dimensions above threshold, make minor enhancements")}
+
+REQUIREMENTS:
+1. Keep the exact name: "{faction.get("name", "Unknown")}"
+2. Make SUBSTANTIAL improvements - add new concrete details, not vague generalities
+3. The description should be at least 3 sentences with specific world details
+4. Output in {brief.language if brief else "English"}
+
+Return ONLY the improved faction."""
+
+    model = svc._get_creator_model(entity_type="faction")
+    refined = generate_structured(
+        settings=svc.settings,
+        model=model,
+        prompt=prompt,
+        response_model=Faction,
+        temperature=temperature,
+    )
+    result = refined.model_dump()
+    result["name"] = faction.get("name", "Unknown")
+    result["type"] = "faction"
+    return result
+
+
+def improved_refine_concept(
+    svc: WorldQualityService,
+    concept: dict[str, Any],
+    scores: ConceptQualityScores,
+    story_state: StoryState,
+    temperature: float,
+) -> dict[str, Any]:
+    """Improved concept refinement prompt."""
+    brief = story_state.brief
+    config = svc.get_config()
+    threshold = config.quality_threshold
+
+    improvement_focus = []
+    if scores.relevance < threshold:
+        improvement_focus.append(
+            f"RELEVANCE ({scores.relevance}/10): Connect more explicitly to story themes"
+        )
+    if scores.depth < threshold:
+        improvement_focus.append(
+            f"DEPTH ({scores.depth}/10): Add philosophical nuance and paradoxes"
+        )
+    if scores.manifestation < threshold:
+        improvement_focus.append(
+            f"MANIFESTATION ({scores.manifestation}/10): Describe specific scenes or events "
+            f"where this concept becomes tangible"
+        )
+    if scores.resonance < threshold:
+        improvement_focus.append(
+            f"RESONANCE ({scores.resonance}/10): Add universal human truths that readers "
+            f"connect with emotionally"
+        )
+
+    prompt = f"""TASK: Improve this concept to meet quality threshold {threshold}/10 average.
+Current average: {scores.average:.1f}/10.
+
+ORIGINAL CONCEPT:
+Name: {concept.get("name", "Unknown")}
+Description: {concept.get("description", "")}
+Manifestations: {concept.get("manifestations", "")}
+
+CURRENT SCORES (target: {threshold}+ average):
+- Relevance: {scores.relevance}/10
+- Depth: {scores.depth}/10
+- Manifestation: {scores.manifestation}/10
+- Resonance: {scores.resonance}/10
+
+JUDGE'S SPECIFIC FEEDBACK (address each point):
+{scores.feedback}
+
+PRIORITY IMPROVEMENTS:
+{_format_improvements(improvement_focus)}
+
+REQUIREMENTS:
+1. Keep the exact name: "{concept.get("name", "Unknown")}"
+2. Make SUBSTANTIAL improvements with concrete details
+3. Output in {brief.language if brief else "English"}
+
+Return ONLY the improved concept."""
+
+    model = svc._get_creator_model(entity_type="concept")
+    refined = generate_structured(
+        settings=svc.settings,
+        model=model,
+        prompt=prompt,
+        response_model=Concept,
+        temperature=temperature,
+    )
+    result = refined.model_dump()
+    result["name"] = concept.get("name", "Unknown")
+    result["type"] = "concept"
+    return result
+
+
+def improved_refine_item(
+    svc: WorldQualityService,
+    item: dict[str, Any],
+    scores: ItemQualityScores,
+    story_state: StoryState,
+    temperature: float,
+) -> dict[str, Any]:
+    """Improved item refinement prompt."""
+    brief = story_state.brief
+    config = svc.get_config()
+    threshold = config.quality_threshold
+
+    improvement_focus = []
+    if scores.significance < threshold:
+        improvement_focus.append(
+            f"SIGNIFICANCE ({scores.significance}/10): Tie the item to specific plot events "
+            f"or character arcs"
+        )
+    if scores.uniqueness < threshold:
+        improvement_focus.append(
+            f"UNIQUENESS ({scores.uniqueness}/10): Add distinctive sensory details or unusual "
+            f"properties"
+        )
+    if scores.narrative_potential < threshold:
+        improvement_focus.append(
+            f"NARRATIVE POTENTIAL ({scores.narrative_potential}/10): Create conflict around "
+            f"possession, use, or discovery"
+        )
+    if scores.integration < threshold:
+        improvement_focus.append(
+            f"INTEGRATION ({scores.integration}/10): Ground in world lore, history, or culture"
+        )
+
+    prompt = f"""TASK: Improve this item to meet quality threshold {threshold}/10 average.
+Current average: {scores.average:.1f}/10.
+
+ORIGINAL ITEM:
+Name: {item.get("name", "Unknown")}
+Description: {item.get("description", "")}
+Significance: {item.get("significance", "")}
+Properties: {", ".join(item.get("properties", [])) if isinstance(item.get("properties"), list) else str(item.get("properties", ""))}
+
+CURRENT SCORES (target: {threshold}+ average):
+- Significance: {scores.significance}/10
+- Uniqueness: {scores.uniqueness}/10
+- Narrative Potential: {scores.narrative_potential}/10
+- Integration: {scores.integration}/10
+
+JUDGE'S SPECIFIC FEEDBACK (address each point):
+{scores.feedback}
+
+PRIORITY IMPROVEMENTS:
+{_format_improvements(improvement_focus)}
+
+REQUIREMENTS:
+1. Keep the exact name: "{item.get("name", "Unknown")}"
+2. Make SUBSTANTIAL improvements
+3. Output in {brief.language if brief else "English"}
+
+Return ONLY the improved item."""
+
+    model = svc._get_creator_model(entity_type="item")
+    refined = generate_structured(
+        settings=svc.settings,
+        model=model,
+        prompt=prompt,
+        response_model=Item,
+        temperature=temperature,
+    )
+    result = refined.model_dump()
+    result["name"] = item.get("name", "Unknown")
+    result["type"] = "item"
+    return result
+
+
+def improved_refine_location(
+    svc: WorldQualityService,
+    location: dict[str, Any],
+    scores: LocationQualityScores,
+    story_state: StoryState,
+    temperature: float,
+) -> dict[str, Any]:
+    """Improved location refinement prompt."""
+    brief = story_state.brief
+    config = svc.get_config()
+    threshold = config.quality_threshold
+
+    improvement_focus = []
+    if scores.atmosphere < threshold:
+        improvement_focus.append(
+            f"ATMOSPHERE ({scores.atmosphere}/10): Add specific sensory details "
+            f"(sounds, smells, light, texture)"
+        )
+    if scores.significance < threshold:
+        improvement_focus.append(
+            f"SIGNIFICANCE ({scores.significance}/10): Connect to plot events or symbolic meaning"
+        )
+    if scores.story_relevance < threshold:
+        improvement_focus.append(
+            f"STORY RELEVANCE ({scores.story_relevance}/10): Link to character arcs "
+            f"or thematic elements"
+        )
+    if scores.distinctiveness < threshold:
+        improvement_focus.append(
+            f"DISTINCTIVENESS ({scores.distinctiveness}/10): Add unique architectural, "
+            f"natural, or cultural features"
+        )
+
+    prompt = f"""TASK: Improve this location to meet quality threshold {threshold}/10 average.
+Current average: {scores.average:.1f}/10.
+
+ORIGINAL LOCATION:
+Name: {location.get("name", "Unknown")}
+Description: {location.get("description", "")}
+Significance: {location.get("significance", "")}
+
+CURRENT SCORES (target: {threshold}+ average):
+- Atmosphere: {scores.atmosphere}/10
+- Significance: {scores.significance}/10
+- Story Relevance: {scores.story_relevance}/10
+- Distinctiveness: {scores.distinctiveness}/10
+
+JUDGE'S SPECIFIC FEEDBACK (address each point):
+{scores.feedback}
+
+PRIORITY IMPROVEMENTS:
+{_format_improvements(improvement_focus)}
+
+REQUIREMENTS:
+1. Keep the exact name: "{location.get("name", "Unknown")}"
+2. Make SUBSTANTIAL improvements with concrete sensory details
+3. Output in {brief.language if brief else "English"}
+
+Return ONLY the improved location."""
+
+    model = svc._get_creator_model(entity_type="location")
+    refined = generate_structured(
+        settings=svc.settings,
+        model=model,
+        prompt=prompt,
+        response_model=Location,
+        temperature=temperature,
+    )
+    result = refined.model_dump()
+    result["name"] = location.get("name", "Unknown")
+    result["type"] = "location"
+    return result
+
+
+# Map entity types to improved refine functions
+IMPROVED_REFINERS = {
+    "character": improved_refine_character,
+    "faction": improved_refine_faction,
+    "concept": improved_refine_concept,
+    "item": improved_refine_item,
+    "location": improved_refine_location,
+}
+
+
+def run_ab_test(
+    svc_container: ServiceContainer,
+    story_state: StoryState,
+    entity_type: str,
+    entity_index: int,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Run A/B test for a single entity.
+
+    1. Create seed entity
+    2. Judge baseline
+    3. Refine with current (A) -> judge
+    4. Refine with improved (B) -> judge
+    5. Compare
+
+    Args:
+        svc_container: Service container.
+        story_state: Story state.
+        entity_type: Entity type.
+        entity_index: Index for logging.
+        verbose: Verbose output.
+
+    Returns:
+        Dict with A/B test results.
+    """
+    wqs = svc_container.world_quality
+    config = wqs.get_config()
+    existing_names: list[str] = []
+
+    result: dict[str, Any] = {
+        "entity_type": entity_type,
+        "entity_index": entity_index,
+        "entity_name": "",
+        "baseline_score": None,
+        "score_a_current": None,
+        "score_b_improved": None,
+        "delta_a": None,
+        "delta_b": None,
+        "delta_ab": None,
+        "baseline_feedback": "",
+        "feedback_a": "",
+        "feedback_b": "",
+        "error": None,
+    }
+
+    try:
+        # Step 1: Create seed entity
+        if entity_type == "character":
+            entity_obj = wqs._create_character(
+                story_state, existing_names, config.creator_temperature
+            )
+            entity_data = entity_obj.model_dump() if entity_obj else None
+        elif entity_type == "faction":
+            entity_data = wqs._create_faction(
+                story_state, existing_names, config.creator_temperature
+            )
+        elif entity_type == "location":
+            entity_data = wqs._create_location(
+                story_state, existing_names, config.creator_temperature
+            )
+        elif entity_type == "item":
+            entity_data = wqs._create_item(story_state, existing_names, config.creator_temperature)
+        elif entity_type == "concept":
+            entity_data = wqs._create_concept(
+                story_state, existing_names, config.creator_temperature
+            )
+        else:
+            result["error"] = f"A/B testing not supported for {entity_type}"
+            return result
+
+        if not entity_data:
+            result["error"] = "Seed creation returned empty"
+            return result
+
+        name = entity_data.get("name", "Unknown")
+        result["entity_name"] = name
+
+        # Step 2: Judge baseline
+        if entity_type == "character":
+            baseline_scores = wqs._judge_character_quality(
+                Character(**entity_data), story_state, config.judge_temperature
+            )
+        elif entity_type == "faction":
+            baseline_scores = wqs._judge_faction_quality(
+                entity_data, story_state, config.judge_temperature
+            )
+        elif entity_type == "location":
+            baseline_scores = wqs._judge_location_quality(
+                entity_data, story_state, config.judge_temperature
+            )
+        elif entity_type == "item":
+            baseline_scores = wqs._judge_item_quality(
+                entity_data, story_state, config.judge_temperature
+            )
+        elif entity_type == "concept":
+            baseline_scores = wqs._judge_concept_quality(
+                entity_data, story_state, config.judge_temperature
+            )
+        else:
+            result["error"] = f"Judging not supported for {entity_type}"
+            return result
+
+        if baseline_scores is None:
+            result["error"] = "Baseline judge returned None"
+            logger.warning("Baseline judge failed for %s #%d", entity_type, entity_index)
+            return result
+
+        result["baseline_score"] = round(baseline_scores.average, 2)
+        result["baseline_feedback"] = baseline_scores.feedback
+
+        if verbose:
+            print(f"    Baseline: {baseline_scores.average:.1f}")
+
+        # Step 3: Refine with CURRENT production prompt (A)
+        refine_temp = config.get_refinement_temperature(2)
+        if entity_type == "character":
+            refined_a_obj = wqs._refine_character(
+                Character(**entity_data), baseline_scores, story_state, refine_temp
+            )
+            refined_a = refined_a_obj.model_dump() if refined_a_obj else None
+        elif entity_type == "faction":
+            refined_a = wqs._refine_faction(entity_data, baseline_scores, story_state, refine_temp)
+        elif entity_type == "location":
+            refined_a = wqs._refine_location(entity_data, baseline_scores, story_state, refine_temp)
+        elif entity_type == "item":
+            refined_a = wqs._refine_item(entity_data, baseline_scores, story_state, refine_temp)
+        elif entity_type == "concept":
+            refined_a = wqs._refine_concept(entity_data, baseline_scores, story_state, refine_temp)
+        else:
+            refined_a = None
+
+        scores_a = None
+        if refined_a:
+            if entity_type == "character":
+                scores_a = wqs._judge_character_quality(
+                    Character(**refined_a), story_state, config.judge_temperature
+                )
+            elif entity_type == "faction":
+                scores_a = wqs._judge_faction_quality(
+                    refined_a, story_state, config.judge_temperature
+                )
+            elif entity_type == "location":
+                scores_a = wqs._judge_location_quality(
+                    refined_a, story_state, config.judge_temperature
+                )
+            elif entity_type == "item":
+                scores_a = wqs._judge_item_quality(refined_a, story_state, config.judge_temperature)
+            elif entity_type == "concept":
+                scores_a = wqs._judge_concept_quality(
+                    refined_a, story_state, config.judge_temperature
+                )
+            else:
+                scores_a = baseline_scores
+
+            if scores_a is None:
+                logger.warning(
+                    "Judge returned None for refined-A %s #%d, skipping A comparison",
+                    entity_type,
+                    entity_index,
+                )
+            else:
+                result["score_a_current"] = round(scores_a.average, 2)
+                result["feedback_a"] = scores_a.feedback
+                result["delta_a"] = round(scores_a.average - baseline_scores.average, 2)
+
+                if verbose:
+                    print(
+                        f"    Current (A): {scores_a.average:.1f} (delta={result['delta_a']:+.1f})"
+                    )
+        else:
+            logger.warning(
+                "Current refiner (A) returned None for %s #%d, skipping A comparison",
+                entity_type,
+                entity_index,
+            )
+
+        # Step 4: Refine with IMPROVED prompt (B) from same seed
+        improved_refiner = IMPROVED_REFINERS.get(entity_type)
+        if improved_refiner:
+            if entity_type == "character":
+                refined_b = improved_refiner(  # type: ignore[operator]
+                    wqs, Character(**entity_data), baseline_scores, story_state, refine_temp
+                )
+                refined_b_data = (
+                    refined_b.model_dump() if hasattr(refined_b, "model_dump") else refined_b
+                )
+            else:
+                refined_b_data = improved_refiner(  # type: ignore[operator]
+                    wqs, entity_data, baseline_scores, story_state, refine_temp
+                )
+
+            if refined_b_data:
+                if entity_type == "character":
+                    scores_b = wqs._judge_character_quality(
+                        Character(**refined_b_data), story_state, config.judge_temperature
+                    )
+                elif entity_type == "faction":
+                    scores_b = wqs._judge_faction_quality(
+                        refined_b_data, story_state, config.judge_temperature
+                    )
+                elif entity_type == "location":
+                    scores_b = wqs._judge_location_quality(
+                        refined_b_data, story_state, config.judge_temperature
+                    )
+                elif entity_type == "item":
+                    scores_b = wqs._judge_item_quality(
+                        refined_b_data, story_state, config.judge_temperature
+                    )
+                elif entity_type == "concept":
+                    scores_b = wqs._judge_concept_quality(
+                        refined_b_data, story_state, config.judge_temperature
+                    )
+                else:
+                    scores_b = baseline_scores
+
+                if scores_b is None:
+                    logger.warning(
+                        "Judge returned None for refined-B %s #%d, skipping B comparison",
+                        entity_type,
+                        entity_index,
+                    )
+                else:
+                    result["score_b_improved"] = round(scores_b.average, 2)
+                    result["feedback_b"] = scores_b.feedback
+                    result["delta_b"] = round(scores_b.average - baseline_scores.average, 2)
+                    if scores_a is not None and result["score_a_current"] is not None:
+                        result["delta_ab"] = round(scores_b.average - scores_a.average, 2)
+
+                    if verbose:
+                        ab_str = (
+                            f"A-B={result['delta_ab']:+.1f}"
+                            if result["delta_ab"] is not None
+                            else "A=N/A"
+                        )
+                        print(
+                            f"    Improved (B): {scores_b.average:.1f} "
+                            f"(delta={result['delta_b']:+.1f}, {ab_str})"
+                        )
+        else:
+            result["error"] = f"No improved refiner for {entity_type}"
+
+    except StoryFactoryError as e:
+        result["error"] = str(e)
+        logger.error("A/B test error for %s #%d: %s", entity_type, entity_index, e)
+
+    return result
+
+
+def main() -> None:
+    """Main entry point for the A/B prompt evaluation script."""
+    parser = argparse.ArgumentParser(description="A/B test current vs improved refine prompts.")
+    parser.add_argument(
+        "--entity-types",
+        type=str,
+        help=f"Comma-separated entity types (default: {', '.join(DEFAULT_AB_TYPES)})",
+    )
+    parser.add_argument(
+        "--count-per-type",
+        type=int,
+        default=3,
+        help="Number of seed entities per type (default: 3)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Output JSON file path (default: output/diagnostics/<timestamp>_ab.json)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print verbose progress to console",
+    )
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    # Parse entity types
+    if args.entity_types:
+        entity_types = [t.strip() for t in args.entity_types.split(",")]
+        invalid = [t for t in entity_types if t not in ALL_ENTITY_TYPES]
+        if invalid:
+            print(f"ERROR: Invalid entity types: {invalid}")
+            sys.exit(1)
+        # Filter to types that have improved refiners
+        unsupported = [t for t in entity_types if t not in IMPROVED_REFINERS]
+        if unsupported:
+            print(f"WARNING: No improved refiner for: {unsupported}. Skipping.")
+            entity_types = [t for t in entity_types if t in IMPROVED_REFINERS]
+    else:
+        entity_types = DEFAULT_AB_TYPES
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        diagnostics_dir = Path("output/diagnostics")
+        diagnostics_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
+        output_path = diagnostics_dir / f"ab_prompts_{timestamp}.json"
+
+    # Initialize services
+    print("Loading settings and initializing services...")
+    settings = Settings.load()
+    svc = ServiceContainer(settings)
+    config = svc.world_quality.get_config()
+
+    # Create canonical story state
+    brief = make_canonical_brief()
+    story_state = make_story_state(brief)
+
+    print(f"Quality threshold: {config.quality_threshold}")
+    print(f"Entity types: {entity_types}")
+    print(f"Count per type: {args.count_per_type}")
+    print(f"Output: {output_path}")
+    print()
+
+    # Run A/B tests
+    ab_results: list[dict[str, Any]] = []
+    total = len(entity_types) * args.count_per_type
+    completed = 0
+
+    for et in entity_types:
+        print(f"--- A/B testing {et} ({args.count_per_type} seeds) ---")
+        for i in range(args.count_per_type):
+            completed += 1
+            print(f"  [{completed}/{total}] {et} #{i + 1}...")
+            result = run_ab_test(svc, story_state, et, i + 1, verbose=args.verbose)
+            ab_results.append(result)
+
+            if result.get("error"):
+                print(f"    ERROR: {result['error']}")
+
+    # Compute per-type summary
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for r in ab_results:
+        by_type.setdefault(r["entity_type"], []).append(r)
+
+    type_summary: dict[str, dict[str, Any]] = {}
+    for et, results in by_type.items():
+        valid = [r for r in results if not r.get("error")]
+        if not valid:
+            type_summary[et] = {"count": 0, "error": "All runs failed"}
+            continue
+
+        baselines = [r["baseline_score"] for r in valid if r["baseline_score"] is not None]
+        deltas_a = [r["delta_a"] for r in valid if r["delta_a"] is not None]
+        deltas_b = [r["delta_b"] for r in valid if r["delta_b"] is not None]
+        deltas_ab = [r["delta_ab"] for r in valid if r["delta_ab"] is not None]
+
+        # Only count wins/ties for runs where both A and B scored
+        comparable = [
+            r
+            for r in valid
+            if r["score_a_current"] is not None and r["score_b_improved"] is not None
+        ]
+
+        type_summary[et] = {
+            "count": len(valid),
+            "avg_baseline": round(sum(baselines) / len(baselines), 2) if baselines else 0.0,
+            "avg_delta_a_current": round(sum(deltas_a) / len(deltas_a), 2) if deltas_a else 0.0,
+            "avg_delta_b_improved": round(sum(deltas_b) / len(deltas_b), 2) if deltas_b else 0.0,
+            "avg_delta_ab": round(sum(deltas_ab) / len(deltas_ab), 2) if deltas_ab else 0.0,
+            "b_wins": sum(1 for r in comparable if r["score_b_improved"] > r["score_a_current"]),
+            "a_wins": sum(1 for r in comparable if r["score_a_current"] > r["score_b_improved"]),
+            "ties": sum(1 for r in comparable if r["score_a_current"] == r["score_b_improved"]),
+        }
+
+    # Build output
+    output = {
+        "run_metadata": {
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "model_creator": svc.world_quality._get_creator_model(),
+            "model_judge": svc.world_quality._get_judge_model(),
+            "quality_threshold": config.quality_threshold,
+            "entity_types": entity_types,
+            "count_per_type": args.count_per_type,
+        },
+        "ab_results": ab_results,
+        "type_summary": type_summary,
+    }
+
+    # Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"\nResults written to {output_path}")
+
+    # Print summary
+    print("\n=== A/B PROMPT TEST SUMMARY ===")
+    print(f"{'Type':<15} {'Baseline':<10} {'Delta A':<10} {'Delta B':<10} {'A-B':<8} {'B Wins':<8}")
+    print("-" * 61)
+    for et in entity_types:
+        s = type_summary.get(et, {})
+        if s.get("error"):
+            print(f"{et:<15} ERROR: {s['error']}")
+            continue
+        print(
+            f"{et:<15} {s.get('avg_baseline', 0):<10.1f} "
+            f"{s.get('avg_delta_a_current', 0):<+10.2f} "
+            f"{s.get('avg_delta_b_improved', 0):<+10.2f} "
+            f"{s.get('avg_delta_ab', 0):<+8.2f} "
+            f"{s.get('b_wins', 0)}/{s.get('count', 0)}"
+        )
+
+    # Decision guidance
+    print("\n=== DECISION GUIDANCE ===")
+    for et in entity_types:
+        s = type_summary.get(et, {})
+        delta_ab = float(s.get("avg_delta_ab", 0))
+        if delta_ab > 0.5:
+            print(f"{et}: IMPROVED prompts help significantly (delta={delta_ab:+.2f})")
+            print("  -> IMPLEMENT prompt changes for this entity type")
+        elif delta_ab > 0.2:
+            print(f"{et}: IMPROVED prompts show modest improvement (delta={delta_ab:+.2f})")
+            print("  -> Consider implementing, but check if judge noise explains the gap")
+        elif delta_ab > -0.2:
+            print(f"{et}: No significant difference (delta={delta_ab:+.2f})")
+            print("  -> Prompt changes alone won't fix this type")
+        else:
+            print(f"{et}: IMPROVED prompts are WORSE (delta={delta_ab:+.2f})")
+            print("  -> Current prompts are better; investigate other causes")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_judge_consistency.py
+++ b/scripts/evaluate_judge_consistency.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Evaluate judge scoring consistency for world building entities.
+
+Submits the same entity to the judge N times to measure scoring variance.
+Determines if the judge is noisy (std > 0.5) or consistent (std < 0.2).
+
+Usage:
+    python scripts/evaluate_judge_consistency.py [options]
+      --entity-types faction,concept  (default: all 6)
+      --judge-calls 5                 (default: 5)
+      --output results.json           (default: output/diagnostics/<timestamp>_judge.json)
+      --verbose
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.evaluate_refinement import (
+    ALL_ENTITY_TYPES,
+    SCORE_DIMENSIONS,
+    make_canonical_brief,
+    make_story_state,
+)
+from src.memory.story_state import Character, StoryState
+from src.services import ServiceContainer
+from src.settings import Settings
+from src.utils.exceptions import StoryFactoryError
+
+logger = logging.getLogger(__name__)
+
+# Verdict thresholds
+NOISY_STD_THRESHOLD = 0.5
+CONSISTENT_STD_THRESHOLD = 0.2
+
+
+def compute_statistics(values: list[float]) -> dict[str, float]:
+    """Compute mean, std, min, max, coefficient of variation for a list of values.
+
+    Args:
+        values: List of numeric values.
+
+    Returns:
+        Dict with mean, std, min, max, cv statistics.
+    """
+    if not values:
+        return {"mean": 0.0, "std": 0.0, "min": 0.0, "max": 0.0, "cv": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+    if n < 2:
+        return {"mean": round(mean, 3), "std": 0.0, "min": mean, "max": mean, "cv": 0.0}
+
+    variance = sum((v - mean) ** 2 for v in values) / (n - 1)
+    std = variance**0.5
+    cv = (std / mean) if mean > 0 else 0.0
+
+    return {
+        "mean": round(mean, 3),
+        "std": round(std, 3),
+        "min": round(min(values), 1),
+        "max": round(max(values), 1),
+        "cv": round(cv, 3),
+    }
+
+
+def compute_feedback_similarity(feedbacks: list[str]) -> float:
+    """Compute pairwise Jaccard word overlap between feedback strings.
+
+    Args:
+        feedbacks: List of feedback strings.
+
+    Returns:
+        Average Jaccard similarity (0-1) across all pairs.
+    """
+    if len(feedbacks) < 2:
+        return 1.0
+
+    word_sets = [set(fb.lower().split()) for fb in feedbacks if fb]
+    if len(word_sets) < 2:
+        return 1.0
+
+    similarities = []
+    for i in range(len(word_sets)):
+        for j in range(i + 1, len(word_sets)):
+            union = word_sets[i] | word_sets[j]
+            if union:
+                intersection = word_sets[i] & word_sets[j]
+                similarities.append(len(intersection) / len(union))
+            else:
+                similarities.append(1.0)
+
+    return round(sum(similarities) / len(similarities), 3) if similarities else 1.0
+
+
+def determine_verdict(per_dimension_stats: dict[str, dict[str, float]]) -> str:
+    """Determine judge consistency verdict from per-dimension statistics.
+
+    Args:
+        per_dimension_stats: Dict mapping dimension name to statistics.
+
+    Returns:
+        One of: "consistent", "noisy", "borderline".
+    """
+    stds = [stats["std"] for stats in per_dimension_stats.values()]
+    if not stds:
+        return "consistent"
+
+    avg_std = sum(stds) / len(stds)
+    max_std = max(stds)
+
+    if max_std > NOISY_STD_THRESHOLD or avg_std > NOISY_STD_THRESHOLD:
+        return "noisy"
+    if max_std < CONSISTENT_STD_THRESHOLD and avg_std < CONSISTENT_STD_THRESHOLD:
+        return "consistent"
+    return "borderline"
+
+
+def create_entity(
+    svc_container: ServiceContainer,
+    story_state: StoryState,
+    entity_type: str,
+) -> tuple[dict[str, Any] | None, str]:
+    """Create a single entity using the production _create_X method.
+
+    Args:
+        svc_container: Service container.
+        story_state: Story state with brief.
+        entity_type: Entity type to create.
+
+    Returns:
+        Tuple of (entity_data, entity_name).
+    """
+    wqs = svc_container.world_quality
+    config = wqs.get_config()
+    existing_names: list[str] = []
+
+    if entity_type == "character":
+        entity_obj = wqs._create_character(story_state, existing_names, config.creator_temperature)
+        if entity_obj:
+            return entity_obj.model_dump(), entity_obj.name
+        return None, ""
+    elif entity_type == "faction":
+        data = wqs._create_faction(story_state, existing_names, config.creator_temperature)
+        return data, data.get("name", "") if data else ""
+    elif entity_type == "location":
+        data = wqs._create_location(story_state, existing_names, config.creator_temperature)
+        return data, data.get("name", "") if data else ""
+    elif entity_type == "item":
+        data = wqs._create_item(story_state, existing_names, config.creator_temperature)
+        return data, data.get("name", "") if data else ""
+    elif entity_type == "concept":
+        data = wqs._create_concept(story_state, existing_names, config.creator_temperature)
+        return data, data.get("name", "") if data else ""
+    elif entity_type == "relationship":
+        entity_names = ["Archivist Sera", "Councillor Vex", "The Pale Librarian"]
+        data = wqs._create_relationship(story_state, entity_names, [], config.creator_temperature)
+        name = f"{data.get('source', '')} -> {data.get('target', '')}" if data else ""
+        return data, name
+
+    return None, ""
+
+
+def judge_entity(
+    svc_container: ServiceContainer,
+    story_state: StoryState,
+    entity_type: str,
+    entity_data: dict[str, Any],
+    temperature: float,
+) -> dict[str, Any] | None:
+    """Judge an entity once and return scores as dict.
+
+    Args:
+        svc_container: Service container.
+        story_state: Story state.
+        entity_type: Entity type.
+        entity_data: Entity data dict.
+        temperature: Judge temperature.
+
+    Returns:
+        Scores dict or None on error.
+    """
+    wqs = svc_container.world_quality
+
+    try:
+        if entity_type == "character":
+            scores = wqs._judge_character_quality(
+                Character(**entity_data), story_state, temperature
+            )
+        elif entity_type == "faction":
+            scores = wqs._judge_faction_quality(entity_data, story_state, temperature)
+        elif entity_type == "location":
+            scores = wqs._judge_location_quality(entity_data, story_state, temperature)
+        elif entity_type == "item":
+            scores = wqs._judge_item_quality(entity_data, story_state, temperature)
+        elif entity_type == "concept":
+            scores = wqs._judge_concept_quality(entity_data, story_state, temperature)
+        elif entity_type == "relationship":
+            scores = wqs._judge_relationship_quality(entity_data, story_state, temperature)
+        else:
+            return None
+
+        score_dict = scores.to_dict()
+        return {
+            "dimensions": {k: v for k, v in score_dict.items() if k not in ("average", "feedback")},
+            "average": round(scores.average, 2),
+            "feedback": scores.feedback,
+        }
+    except StoryFactoryError as e:
+        logger.error("Judge error for %s: %s", entity_type, e)
+        return None
+
+
+def run_judge_consistency_test(
+    svc_container: ServiceContainer,
+    story_state: StoryState,
+    entity_type: str,
+    judge_calls: int,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Run judge consistency test for one entity type.
+
+    1. Generate one entity with _create_X()
+    2. Call _judge_X_quality() N times on the frozen entity
+    3. Compute statistics
+
+    Args:
+        svc_container: Service container.
+        story_state: Story state.
+        entity_type: Entity type.
+        judge_calls: Number of judge calls.
+        verbose: Verbose output.
+
+    Returns:
+        Dict with consistency test results.
+    """
+    config = svc_container.world_quality.get_config()
+
+    result: dict[str, Any] = {
+        "entity_type": entity_type,
+        "entity_name": "",
+        "entity_data": None,
+        "judge_calls": judge_calls,
+        "judge_temperature": config.judge_temperature,
+        "individual_scores": [],
+        "per_dimension_stats": {},
+        "average_stats": {},
+        "feedback_similarity": 0.0,
+        "verdict": "",
+        "error": None,
+    }
+
+    # Step 1: Create entity
+    print(f"  Creating {entity_type}...")
+    start = time.monotonic()
+    try:
+        entity_data, entity_name = create_entity(svc_container, story_state, entity_type)
+    except StoryFactoryError as e:
+        result["error"] = f"Creation failed: {e}"
+        logger.error("Failed to create %s: %s", entity_type, e)
+        return result
+
+    if not entity_data:
+        result["error"] = "Creation returned empty entity"
+        return result
+
+    result["entity_name"] = entity_name
+    result["entity_data"] = entity_data
+    create_time = round(time.monotonic() - start, 2)
+    print(f"    Created '{entity_name}' in {create_time}s")
+
+    # Step 2: Judge N times
+    feedbacks: list[str] = []
+    averages: list[float] = []
+    dimension_scores: dict[str, list[float]] = {
+        dim: [] for dim in SCORE_DIMENSIONS.get(entity_type, [])
+    }
+
+    for call_idx in range(judge_calls):
+        call_start = time.monotonic()
+        judge_result = judge_entity(
+            svc_container, story_state, entity_type, entity_data, config.judge_temperature
+        )
+        call_time = round(time.monotonic() - call_start, 2)
+
+        if judge_result is None:
+            result["individual_scores"].append({"error": "Judge call failed"})
+            logger.warning("Judge call %d/%d failed for %s", call_idx + 1, judge_calls, entity_type)
+            continue
+
+        result["individual_scores"].append(judge_result)
+        averages.append(judge_result["average"])
+        feedbacks.append(judge_result["feedback"])
+
+        for dim, value in judge_result["dimensions"].items():
+            if dim in dimension_scores:
+                dimension_scores[dim].append(float(value))
+
+        if verbose:
+            dims_str = ", ".join(
+                f"{d}={judge_result['dimensions'].get(d, '?')}"
+                for d in SCORE_DIMENSIONS.get(entity_type, [])
+            )
+            print(
+                f"    Call {call_idx + 1}/{judge_calls}: avg={judge_result['average']:.1f} "
+                f"({dims_str}) [{call_time}s]"
+            )
+
+    # Step 3: Compute statistics
+    if not averages:
+        logger.warning(
+            "No successful judge calls for %s — cannot compute consistency stats",
+            entity_type,
+        )
+        result["verdict"] = "insufficient_data"
+        return result
+
+    result["average_stats"] = compute_statistics(averages)
+
+    per_dim_stats = {}
+    for dim, values in dimension_scores.items():
+        if values:
+            per_dim_stats[dim] = compute_statistics(values)
+    result["per_dimension_stats"] = per_dim_stats
+
+    result["feedback_similarity"] = compute_feedback_similarity(feedbacks)
+    result["verdict"] = determine_verdict(per_dim_stats)
+
+    return result
+
+
+def main() -> None:
+    """Main entry point for the judge consistency evaluation script."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate judge scoring consistency for world building entities."
+    )
+    parser.add_argument(
+        "--entity-types",
+        type=str,
+        help=f"Comma-separated entity types (default: all). Options: {', '.join(ALL_ENTITY_TYPES)}",
+    )
+    parser.add_argument(
+        "--judge-calls",
+        type=int,
+        default=5,
+        help="Number of judge calls per entity (default: 5)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Output JSON file path (default: output/diagnostics/<timestamp>_judge.json)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print verbose progress to console",
+    )
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    # Parse entity types
+    if args.entity_types:
+        entity_types = [t.strip() for t in args.entity_types.split(",")]
+        invalid = [t for t in entity_types if t not in ALL_ENTITY_TYPES]
+        if invalid:
+            print(f"ERROR: Invalid entity types: {invalid}")
+            sys.exit(1)
+    else:
+        entity_types = ALL_ENTITY_TYPES
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        diagnostics_dir = Path("output/diagnostics")
+        diagnostics_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
+        output_path = diagnostics_dir / f"judge_consistency_{timestamp}.json"
+
+    # Initialize services
+    print("Loading settings and initializing services...")
+    settings = Settings.load()
+    svc = ServiceContainer(settings)
+    config = svc.world_quality.get_config()
+
+    # Create canonical story state
+    brief = make_canonical_brief()
+    story_state = make_story_state(brief)
+
+    print(f"Judge temperature: {config.judge_temperature}")
+    print(f"Judge calls per entity: {args.judge_calls}")
+    print(f"Entity types: {entity_types}")
+    print(f"Output: {output_path}")
+    print()
+
+    # Run consistency tests
+    results: list[dict[str, Any]] = []
+    for et in entity_types:
+        print(f"--- Testing {et} judge consistency ({args.judge_calls} calls) ---")
+        result = run_judge_consistency_test(svc, story_state, et, args.judge_calls, args.verbose)
+        results.append(result)
+
+        verdict = result.get("verdict", "error")
+        avg_stats = result.get("average_stats", {})
+        fb_sim = result.get("feedback_similarity", 0)
+        print(
+            f"  Verdict: {verdict.upper()} | "
+            f"avg={avg_stats.get('mean', 0):.1f} std={avg_stats.get('std', 0):.2f} | "
+            f"feedback_similarity={fb_sim:.2f}"
+        )
+        print()
+
+    # Build output
+    output = {
+        "run_metadata": {
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "model_judge": svc.world_quality._get_judge_model(),
+            "judge_temperature": config.judge_temperature,
+            "judge_calls_per_entity": args.judge_calls,
+            "entity_types": entity_types,
+            "thresholds": {
+                "noisy": NOISY_STD_THRESHOLD,
+                "consistent": CONSISTENT_STD_THRESHOLD,
+            },
+        },
+        "results": results,
+    }
+
+    # Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"Results written to {output_path}")
+
+    # Print summary table
+    print("\n=== JUDGE CONSISTENCY SUMMARY ===")
+    print(f"{'Type':<15} {'Verdict':<12} {'Mean':<8} {'Std':<8} {'Range':<12} {'FB Sim':<8}")
+    print("-" * 63)
+    for r in results:
+        et = r["entity_type"]
+        v = r.get("verdict", "error").upper()
+        avg = r.get("average_stats", {})
+        fb = r.get("feedback_similarity", 0)
+        range_str = f"{avg.get('min', 0):.1f}-{avg.get('max', 0):.1f}"
+        print(
+            f"{et:<15} {v:<12} {avg.get('mean', 0):<8.1f} "
+            f"{avg.get('std', 0):<8.2f} {range_str:<12} {fb:<8.2f}"
+        )
+
+    # Decision guidance
+    print("\n=== DECISION GUIDANCE ===")
+    noisy_types = [r["entity_type"] for r in results if r.get("verdict") == "noisy"]
+    consistent_types = [r["entity_type"] for r in results if r.get("verdict") == "consistent"]
+    borderline_types = [r["entity_type"] for r in results if r.get("verdict") == "borderline"]
+
+    if noisy_types:
+        print(f"NOISY judges ({', '.join(noisy_types)}): Fix judge first!")
+        print("  -> Consider: multi-call averaging, lower temperature, or structured output")
+    if consistent_types:
+        print(
+            f"CONSISTENT judges ({', '.join(consistent_types)}): Problem is in creation/refinement"
+        )
+        print("  -> Run evaluate_refinement.py to diagnose further")
+    if borderline_types:
+        print(f"BORDERLINE ({', '.join(borderline_types)}): Some noise but not critical")
+        print("  -> May benefit from multi-call averaging but not blocking")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_refinement.py
+++ b/scripts/evaluate_refinement.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+"""Evaluate refinement loop effectiveness for world building entities.
+
+Runs real refinement loops against a live Ollama model with full instrumentation
+to diagnose WHY the quality refinement loop has a high fail rate.
+
+Captures per entity per iteration:
+- Entity data snapshot (full dict/model dump)
+- Per-dimension scores and average
+- Judge feedback string (verbatim)
+- Description diff ratio vs previous iteration
+- Temperature used
+- Wall clock time
+
+Usage:
+    python scripts/evaluate_refinement.py [options]
+      --entity-types faction,concept  (default: all 6)
+      --count-per-type 3              (default: 3)
+      --output results.json           (default: output/diagnostics/<timestamp>.json)
+      --verbose
+"""
+
+import argparse
+import difflib
+import json
+import logging
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.memory.story_state import Character, StoryBrief, StoryState
+from src.services import ServiceContainer
+from src.settings import Settings
+from src.utils.exceptions import StoryFactoryError
+
+logger = logging.getLogger(__name__)
+
+ALL_ENTITY_TYPES = ["character", "faction", "location", "item", "concept", "relationship"]
+
+# Score dimension names per entity type (for reporting)
+SCORE_DIMENSIONS: dict[str, list[str]] = {
+    "character": ["depth", "goals", "flaws", "uniqueness", "arc_potential"],
+    "faction": ["coherence", "influence", "conflict_potential", "distinctiveness"],
+    "location": ["atmosphere", "significance", "story_relevance", "distinctiveness"],
+    "item": ["significance", "uniqueness", "narrative_potential", "integration"],
+    "concept": ["relevance", "depth", "manifestation", "resonance"],
+    "relationship": ["tension", "dynamics", "story_potential", "authenticity"],
+}
+
+
+def make_canonical_brief() -> StoryBrief:
+    """Create a canonical StoryBrief for reproducible diagnostics.
+
+    Fantasy premise with political intrigue themes that exercises all entity types well.
+    """
+    return StoryBrief(
+        premise=(
+            "In a crumbling empire where magic is fueled by memory, a disgraced archivist "
+            "discovers that the ruling council has been erasing collective memories to maintain "
+            "power. She must navigate rival factions, ancient artifacts, and forbidden knowledge "
+            "to restore what was lost before the empire collapses into civil war."
+        ),
+        genre="Fantasy",
+        subgenres=["Political Intrigue", "Dark Fantasy"],
+        tone="Dark and suspenseful with moments of wonder",
+        themes=["Memory and identity", "Power and corruption", "Truth vs stability"],
+        setting_time="Late imperial era, roughly equivalent to 18th century",
+        setting_place="The Mnemorian Empire, a vast realm of stone cities and forgotten libraries",
+        target_length="novel",
+        language="English",
+        content_rating="moderate",
+        content_preferences=["Complex politics", "Morally grey characters", "Magic systems"],
+        content_avoid=["Gratuitous violence", "Sexual content"],
+        additional_notes="Focus on worldbuilding depth and faction dynamics.",
+    )
+
+
+def make_story_state(brief: StoryBrief) -> StoryState:
+    """Create a minimal StoryState wrapping the canonical brief."""
+    return StoryState(
+        id="diagnostic-run",
+        brief=brief,
+        project_name="Refinement Diagnostic",
+    )
+
+
+def compute_description_diff(prev_desc: str, curr_desc: str) -> float:
+    """Compute diff ratio between two description strings.
+
+    Returns a float in [0, 1] where 0 means identical and 1 means completely different.
+    Uses SequenceMatcher which gives a ratio of matching characters.
+    We invert it: diff_ratio = 1.0 - similarity_ratio.
+
+    Args:
+        prev_desc: Previous description text.
+        curr_desc: Current description text.
+
+    Returns:
+        Diff ratio where higher means more change.
+    """
+    if not prev_desc and not curr_desc:
+        return 0.0
+    similarity = difflib.SequenceMatcher(None, prev_desc, curr_desc).ratio()
+    return round(1.0 - similarity, 4)
+
+
+def extract_description(entity_data: dict[str, Any] | None, entity_type: str) -> str:
+    """Extract the primary description field from entity data.
+
+    Args:
+        entity_data: Entity dictionary or None.
+        entity_type: Type of entity.
+
+    Returns:
+        Description string, empty if not found.
+    """
+    if not entity_data:
+        return ""
+    desc = str(entity_data.get("description", ""))
+    # For relationships, also include the relation type and targets
+    if entity_type == "relationship":
+        parts = [
+            str(entity_data.get("source", "")),
+            str(entity_data.get("target", "")),
+            str(entity_data.get("relation_type", "")),
+            desc,
+        ]
+        return " | ".join(p for p in parts if p)
+    return desc
+
+
+def compute_feedback_specificity(feedback: str, entity_data: dict[str, Any]) -> float:
+    """Compute what fraction of feedback words reference entity-specific content.
+
+    A rough heuristic: count words in the feedback that also appear in the entity's
+    name or description, divided by total feedback words. Higher = more specific.
+
+    Args:
+        feedback: Judge feedback string.
+        entity_data: Entity data dict.
+
+    Returns:
+        Float ratio of entity-specific words in feedback.
+    """
+    if not feedback:
+        return 0.0
+    feedback_words = set(feedback.lower().split())
+    if not feedback_words:
+        return 0.0
+
+    # Collect entity-specific words from name, description, goals, values
+    entity_text_parts = []
+    for key in ["name", "description", "significance", "manifestations", "leader"]:
+        val = entity_data.get(key, "")
+        if isinstance(val, str):
+            entity_text_parts.append(val)
+    for key in ["goals", "values", "personality_traits", "properties"]:
+        val = entity_data.get(key, [])
+        if isinstance(val, list):
+            entity_text_parts.extend(str(v) for v in val)
+
+    entity_words = set(" ".join(entity_text_parts).lower().split())
+    # Remove very common words that would inflate the count
+    stop_words = {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "and",
+        "or",
+        "but",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "from",
+        "it",
+        "its",
+        "this",
+        "that",
+        "these",
+        "those",
+        "has",
+        "have",
+        "had",
+        "not",
+        "no",
+        "as",
+        "if",
+        "they",
+        "their",
+        "them",
+    }
+    entity_words -= stop_words
+    feedback_words -= stop_words
+
+    if not feedback_words:
+        return 0.0
+
+    overlap = feedback_words & entity_words
+    return round(len(overlap) / len(feedback_words), 4)
+
+
+def run_single_entity(
+    svc_container: ServiceContainer,
+    story_state: StoryState,
+    entity_type: str,
+    entity_index: int,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    """Run a full create-judge-refine loop for a single entity with instrumentation.
+
+    Args:
+        svc_container: Service container with WorldQualityService.
+        story_state: Story state with canonical brief.
+        entity_type: One of the 6 entity types.
+        entity_index: Index for this entity (for logging).
+        verbose: Whether to print verbose progress.
+
+    Returns:
+        Dict with full diagnostic data for this entity.
+    """
+    wqs = svc_container.world_quality
+    config = wqs.get_config()
+    existing_names: list[str] = []
+    start_time = time.monotonic()
+
+    result: dict[str, Any] = {
+        "entity_type": entity_type,
+        "entity_index": entity_index,
+        "entity_name": "",
+        "threshold_met": False,
+        "iterations": [],
+        "score_progression": [],
+        "feedback_strings": [],
+        "description_diff_ratios": [],
+        "feedback_specificity_scores": [],
+        "total_time_s": 0.0,
+        "error": None,
+    }
+
+    prev_description = ""
+    entity_data: dict[str, Any] | None = None
+    scores = None
+
+    for iteration in range(config.max_iterations):
+        iter_start = time.monotonic()
+        iter_record: dict[str, Any] = {
+            "iteration": iteration + 1,
+            "phase": "create" if iteration == 0 else "refine",
+            "temperature": 0.0,
+            "scores": {},
+            "average_score": 0.0,
+            "feedback": "",
+            "description_diff_ratio": None,
+            "feedback_specificity": 0.0,
+            "wall_clock_s": 0.0,
+            "entity_snapshot": None,
+            "error": None,
+        }
+
+        try:
+            # Phase 1: Create or Refine
+            # Re-create if no entity data or no scores from previous judge failure
+            if iteration == 0 or entity_data is None or scores is None:
+                iter_record["phase"] = "create"
+                iter_record["temperature"] = config.creator_temperature
+                if entity_type == "character":
+                    entity_obj = wqs._create_character(
+                        story_state, existing_names, config.creator_temperature
+                    )
+                    entity_data = entity_obj.model_dump() if entity_obj else None
+                elif entity_type == "faction":
+                    entity_data = wqs._create_faction(
+                        story_state, existing_names, config.creator_temperature
+                    )
+                elif entity_type == "location":
+                    entity_data = wqs._create_location(
+                        story_state, existing_names, config.creator_temperature
+                    )
+                elif entity_type == "item":
+                    entity_data = wqs._create_item(
+                        story_state, existing_names, config.creator_temperature
+                    )
+                elif entity_type == "concept":
+                    entity_data = wqs._create_concept(
+                        story_state, existing_names, config.creator_temperature
+                    )
+                elif entity_type == "relationship":
+                    entity_names = ["Archivist Sera", "Councillor Vex", "The Pale Librarian"]
+                    entity_data = wqs._create_relationship(
+                        story_state, entity_names, [], config.creator_temperature
+                    )
+            else:
+                dynamic_temp = config.get_refinement_temperature(iteration + 1)
+                iter_record["temperature"] = dynamic_temp
+                iter_record["phase"] = "refine"
+
+                if entity_type == "character":
+                    entity_obj = wqs._refine_character(
+                        Character(**entity_data), scores, story_state, dynamic_temp
+                    )
+                    entity_data = entity_obj.model_dump() if entity_obj else None
+                elif entity_type == "faction":
+                    entity_data = wqs._refine_faction(
+                        entity_data, scores, story_state, dynamic_temp
+                    )
+                elif entity_type == "location":
+                    entity_data = wqs._refine_location(
+                        entity_data, scores, story_state, dynamic_temp
+                    )
+                elif entity_type == "item":
+                    entity_data = wqs._refine_item(entity_data, scores, story_state, dynamic_temp)
+                elif entity_type == "concept":
+                    entity_data = wqs._refine_concept(
+                        entity_data, scores, story_state, dynamic_temp
+                    )
+                elif entity_type == "relationship":
+                    entity_data = wqs._refine_relationship(
+                        entity_data, scores, story_state, dynamic_temp
+                    )
+
+            if not entity_data or (
+                isinstance(entity_data, dict)
+                and not entity_data.get("name")
+                and entity_type != "relationship"
+            ):
+                iter_record["error"] = "Entity creation returned empty"
+                iter_record["wall_clock_s"] = round(time.monotonic() - iter_start, 2)
+                result["iterations"].append(iter_record)
+                logger.warning(
+                    "Entity %s #%d iteration %d: creation returned empty",
+                    entity_type,
+                    entity_index,
+                    iteration + 1,
+                )
+                continue
+
+            # Set entity name on first successful creation
+            if not result["entity_name"]:
+                name = entity_data.get("name", "")
+                if entity_type == "relationship":
+                    name = f"{entity_data.get('source', '')} -> {entity_data.get('target', '')}"
+                result["entity_name"] = name
+
+            iter_record["entity_snapshot"] = (
+                entity_data.copy() if isinstance(entity_data, dict) else entity_data
+            )
+
+            # Compute description diff
+            curr_description = extract_description(entity_data, entity_type)
+            if iteration == 0:
+                iter_record["description_diff_ratio"] = None
+            else:
+                diff_ratio = compute_description_diff(prev_description, curr_description)
+                iter_record["description_diff_ratio"] = diff_ratio
+            prev_description = curr_description
+
+            # Phase 2: Judge
+            if entity_type == "character":
+                scores = wqs._judge_character_quality(
+                    Character(**entity_data), story_state, config.judge_temperature
+                )
+            elif entity_type == "faction":
+                scores = wqs._judge_faction_quality(
+                    entity_data, story_state, config.judge_temperature
+                )
+            elif entity_type == "location":
+                scores = wqs._judge_location_quality(
+                    entity_data, story_state, config.judge_temperature
+                )
+            elif entity_type == "item":
+                scores = wqs._judge_item_quality(entity_data, story_state, config.judge_temperature)
+            elif entity_type == "concept":
+                scores = wqs._judge_concept_quality(
+                    entity_data, story_state, config.judge_temperature
+                )
+            elif entity_type == "relationship":
+                scores = wqs._judge_relationship_quality(
+                    entity_data, story_state, config.judge_temperature
+                )
+
+            if scores is None:
+                iter_record["error"] = f"No judge for entity type: {entity_type}"
+                iter_record["wall_clock_s"] = round(time.monotonic() - iter_start, 2)
+                result["iterations"].append(iter_record)
+                logger.warning(
+                    "Entity %s #%d iteration %d: judge returned None",
+                    entity_type,
+                    entity_index,
+                    iteration + 1,
+                )
+                continue
+
+            score_dict = scores.to_dict()
+            avg = scores.average
+            feedback = scores.feedback
+
+            iter_record["scores"] = {
+                k: v for k, v in score_dict.items() if k not in ("average", "feedback")
+            }
+            iter_record["average_score"] = round(avg, 2)
+            iter_record["feedback"] = feedback
+
+            # Feedback specificity
+            specificity = compute_feedback_specificity(feedback, entity_data)
+            iter_record["feedback_specificity"] = specificity
+
+            iter_record["wall_clock_s"] = round(time.monotonic() - iter_start, 2)
+            result["iterations"].append(iter_record)
+            result["score_progression"].append(round(avg, 2))
+            result["feedback_strings"].append(feedback)
+            result["description_diff_ratios"].append(iter_record["description_diff_ratio"])
+            result["feedback_specificity_scores"].append(specificity)
+
+            if verbose:
+                print(
+                    f"  Iter {iteration + 1}: avg={avg:.1f} "
+                    f"diff={iter_record['description_diff_ratio']} "
+                    f"time={iter_record['wall_clock_s']}s"
+                )
+
+            # Check threshold
+            if avg >= config.quality_threshold:
+                result["threshold_met"] = True
+                logger.info(
+                    "Entity %s '%s' met threshold at iteration %d (%.1f >= %.1f)",
+                    entity_type,
+                    result["entity_name"],
+                    iteration + 1,
+                    avg,
+                    config.quality_threshold,
+                )
+                break
+
+        except StoryFactoryError as e:
+            iter_record["error"] = str(e)
+            iter_record["wall_clock_s"] = round(time.monotonic() - iter_start, 2)
+            result["iterations"].append(iter_record)
+            logger.error(
+                "Entity %s #%d iteration %d error: %s",
+                entity_type,
+                entity_index,
+                iteration + 1,
+                e,
+            )
+
+    result["total_time_s"] = round(time.monotonic() - start_time, 2)
+    return result
+
+
+def compute_summary(entity_results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute summary statistics from entity results.
+
+    Args:
+        entity_results: List of per-entity diagnostic results.
+
+    Returns:
+        Summary dict with aggregated metrics per entity type.
+    """
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for r in entity_results:
+        et = r["entity_type"]
+        by_type.setdefault(et, []).append(r)
+
+    summary: dict[str, Any] = {
+        "pass_rate_by_type": {},
+        "avg_score_improvement_per_iteration": {},
+        "avg_description_diff_ratio": {},
+        "avg_feedback_length": {},
+        "avg_feedback_specificity": {},
+        "plateau_rate": {},
+        "regression_rate": {},
+    }
+
+    for et, results in by_type.items():
+        total = len(results)
+        passed = sum(1 for r in results if r["threshold_met"])
+        summary["pass_rate_by_type"][et] = round(passed / total, 2) if total else 0.0
+
+        # Score improvement per iteration
+        improvements = []
+        for r in results:
+            prog = r["score_progression"]
+            for i in range(1, len(prog)):
+                improvements.append(prog[i] - prog[i - 1])
+        summary["avg_score_improvement_per_iteration"][et] = (
+            round(sum(improvements) / len(improvements), 3) if improvements else 0.0
+        )
+
+        # Description diff ratio (skip first None)
+        diffs = []
+        for r in results:
+            for d in r["description_diff_ratios"]:
+                if d is not None:
+                    diffs.append(d)
+        summary["avg_description_diff_ratio"][et] = (
+            round(sum(diffs) / len(diffs), 3) if diffs else 0.0
+        )
+
+        # Feedback length
+        fb_lengths = []
+        for r in results:
+            for fb in r["feedback_strings"]:
+                fb_lengths.append(len(fb.split()))
+        summary["avg_feedback_length"][et] = (
+            round(sum(fb_lengths) / len(fb_lengths), 1) if fb_lengths else 0.0
+        )
+
+        # Feedback specificity
+        specificities = []
+        for r in results:
+            specificities.extend(r["feedback_specificity_scores"])
+        summary["avg_feedback_specificity"][et] = (
+            round(sum(specificities) / len(specificities), 3) if specificities else 0.0
+        )
+
+        # Plateau rate: iterations where |delta| < 0.3 / total refinement iterations
+        plateau_count = 0
+        refinement_iters = 0
+        for r in results:
+            prog = r["score_progression"]
+            for i in range(1, len(prog)):
+                refinement_iters += 1
+                if abs(prog[i] - prog[i - 1]) < 0.3:
+                    plateau_count += 1
+        summary["plateau_rate"][et] = (
+            round(plateau_count / refinement_iters, 3) if refinement_iters else 0.0
+        )
+
+        # Regression rate: iterations where delta < 0 / total refinement iterations
+        regression_count = 0
+        for r in results:
+            prog = r["score_progression"]
+            for i in range(1, len(prog)):
+                if prog[i] < prog[i - 1]:
+                    regression_count += 1
+        summary["regression_rate"][et] = (
+            round(regression_count / refinement_iters, 3) if refinement_iters else 0.0
+        )
+
+    return summary
+
+
+def main() -> None:
+    """Main entry point for the refinement evaluation script."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate refinement loop effectiveness for world building entities."
+    )
+    parser.add_argument(
+        "--entity-types",
+        type=str,
+        help=f"Comma-separated entity types (default: all). Options: {', '.join(ALL_ENTITY_TYPES)}",
+    )
+    parser.add_argument(
+        "--count-per-type",
+        type=int,
+        default=3,
+        help="Number of entities to generate per type (default: 3)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Output JSON file path (default: output/diagnostics/<timestamp>.json)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print verbose progress to console",
+    )
+    args = parser.parse_args()
+
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    # Parse entity types
+    if args.entity_types:
+        entity_types = [t.strip() for t in args.entity_types.split(",")]
+        invalid = [t for t in entity_types if t not in ALL_ENTITY_TYPES]
+        if invalid:
+            print(f"ERROR: Invalid entity types: {invalid}")
+            print(f"Valid types: {ALL_ENTITY_TYPES}")
+            sys.exit(1)
+    else:
+        entity_types = ALL_ENTITY_TYPES
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        diagnostics_dir = Path("output/diagnostics")
+        diagnostics_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%d_%H%M%S")
+        output_path = diagnostics_dir / f"refinement_{timestamp}.json"
+
+    # Initialize services
+    print("Loading settings and initializing services...")
+    settings = Settings.load()
+    svc = ServiceContainer(settings)
+    config = svc.world_quality.get_config()
+
+    # Create canonical story state
+    brief = make_canonical_brief()
+    story_state = make_story_state(brief)
+
+    print(f"Configuration: threshold={config.quality_threshold}, max_iter={config.max_iterations}")
+    print(f"Entity types: {entity_types}")
+    print(f"Count per type: {args.count_per_type}")
+    print(f"Output: {output_path}")
+    print()
+
+    # Run evaluations
+    entity_results: list[dict[str, Any]] = []
+    total = len(entity_types) * args.count_per_type
+    completed = 0
+
+    for et in entity_types:
+        print(f"--- Evaluating {et} ({args.count_per_type} entities) ---")
+        for i in range(args.count_per_type):
+            completed += 1
+            print(f"  [{completed}/{total}] {et} #{i + 1}...")
+            result = run_single_entity(svc, story_state, et, i + 1, verbose=args.verbose)
+            entity_results.append(result)
+            name = result["entity_name"] or "(unnamed)"
+            passed = "PASS" if result["threshold_met"] else "FAIL"
+            scores = result["score_progression"]
+            score_str = " -> ".join(f"{s:.1f}" for s in scores) if scores else "no scores"
+            print(f"    {passed}: '{name}' scores: {score_str} ({result['total_time_s']}s)")
+
+    # Compute summary
+    summary = compute_summary(entity_results)
+
+    # Build output
+    output = {
+        "run_metadata": {
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "model_creator": svc.world_quality._get_creator_model(),
+            "model_judge": svc.world_quality._get_judge_model(),
+            "config": {
+                "quality_threshold": config.quality_threshold,
+                "max_iterations": config.max_iterations,
+                "creator_temperature": config.creator_temperature,
+                "judge_temperature": config.judge_temperature,
+                "refinement_temp_start": config.refinement_temp_start,
+                "refinement_temp_end": config.refinement_temp_end,
+                "refinement_temp_decay": config.refinement_temp_decay,
+            },
+            "brief_premise": brief.premise[:200],
+            "entity_types": entity_types,
+            "count_per_type": args.count_per_type,
+        },
+        "entity_results": entity_results,
+        "summary": summary,
+    }
+
+    # Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"\nResults written to {output_path}")
+
+    # Print summary
+    print("\n=== SUMMARY ===")
+    print(
+        f"{'Type':<15} {'Pass%':<8} {'Avg Imp':<10} {'Diff Ratio':<12} "
+        f"{'Plateau%':<10} {'Regress%':<10}"
+    )
+    print("-" * 65)
+    for et in entity_types:
+        pr = summary["pass_rate_by_type"].get(et, 0)
+        ai = summary["avg_score_improvement_per_iteration"].get(et, 0)
+        dr = summary["avg_description_diff_ratio"].get(et, 0)
+        plat = summary["plateau_rate"].get(et, 0)
+        reg = summary["regression_rate"].get(et, 0)
+        print(f"{et:<15} {pr:<8.0%} {ai:<10.3f} {dr:<12.3f} {plat:<10.1%} {reg:<10.1%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_refinement_diagnostics.py
+++ b/tests/unit/test_refinement_diagnostics.py
@@ -1,0 +1,669 @@
+"""Unit tests for refinement diagnostic utility functions.
+
+Tests the helper functions used by the diagnostic scripts in scripts/.
+These tests do NOT require a running Ollama instance.
+"""
+
+from scripts.evaluate_ab_prompts import DEFAULT_AB_TYPES, IMPROVED_REFINERS
+from scripts.evaluate_judge_consistency import (
+    CONSISTENT_STD_THRESHOLD,
+    NOISY_STD_THRESHOLD,
+    compute_feedback_similarity,
+    compute_statistics,
+    determine_verdict,
+)
+from scripts.evaluate_refinement import (
+    ALL_ENTITY_TYPES,
+    SCORE_DIMENSIONS,
+    compute_description_diff,
+    compute_feedback_specificity,
+    compute_summary,
+    extract_description,
+    make_canonical_brief,
+    make_story_state,
+)
+
+
+class TestComputeDescriptionDiff:
+    """Tests for compute_description_diff()."""
+
+    def test_identical_strings_return_zero(self):
+        """Identical strings should have zero diff."""
+        assert compute_description_diff("hello world", "hello world") == 0.0
+
+    def test_completely_different_strings_return_high(self):
+        """Completely different strings should have high diff ratio."""
+        diff = compute_description_diff("aaaa", "zzzz")
+        assert diff > 0.8
+
+    def test_empty_strings_return_zero(self):
+        """Two empty strings should have zero diff."""
+        assert compute_description_diff("", "") == 0.0
+
+    def test_one_empty_returns_one(self):
+        """One empty string vs non-empty should return 1.0."""
+        diff = compute_description_diff("", "some text here")
+        assert diff == 1.0
+
+    def test_similar_strings_return_low(self):
+        """Similar strings with minor changes should return low diff."""
+        diff = compute_description_diff(
+            "The dark fortress stands on the hill",
+            "The dark fortress stands on the mountain",
+        )
+        assert 0.0 < diff < 0.5
+
+    def test_return_is_rounded(self):
+        """Diff ratio should be rounded to 4 decimal places."""
+        diff = compute_description_diff("abc", "abd")
+        assert diff == round(diff, 4)
+
+    def test_both_directions_similar(self):
+        """SequenceMatcher is not perfectly symmetric, but results should be close."""
+        a = "The ancient library holds many secrets"
+        b = "The library was rebuilt with new technology"
+        diff_ab = compute_description_diff(a, b)
+        diff_ba = compute_description_diff(b, a)
+        assert abs(diff_ab - diff_ba) < 0.1
+        assert diff_ab > 0.3
+        assert diff_ba > 0.3
+
+
+class TestExtractDescription:
+    """Tests for extract_description()."""
+
+    def test_returns_description_from_dict(self):
+        """Should extract description field from entity dict."""
+        data = {"name": "Test", "description": "A great place"}
+        assert extract_description(data, "location") == "A great place"
+
+    def test_returns_empty_for_none(self):
+        """Should return empty string for None entity data."""
+        assert extract_description(None, "faction") == ""
+
+    def test_returns_empty_for_missing_key(self):
+        """Should return empty string when description key is absent."""
+        assert extract_description({"name": "Test"}, "faction") == ""
+
+    def test_relationship_includes_source_target(self):
+        """Relationship extraction should include source, target, and relation type."""
+        data = {
+            "source": "Alice",
+            "target": "Bob",
+            "relation_type": "allies_with",
+            "description": "Old friends",
+        }
+        result = extract_description(data, "relationship")
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "allies_with" in result
+        assert "Old friends" in result
+
+
+class TestComputeFeedbackSpecificity:
+    """Tests for compute_feedback_specificity()."""
+
+    def test_empty_feedback_returns_zero(self):
+        """Empty feedback string should return 0.0 specificity."""
+        assert compute_feedback_specificity("", {"name": "Test"}) == 0.0
+
+    def test_generic_feedback_returns_low(self):
+        """Generic feedback without entity-specific words should score low."""
+        feedback = "This is good but could be better overall"
+        entity = {"name": "Iron Covenant", "description": "A secretive military order"}
+        specificity = compute_feedback_specificity(feedback, entity)
+        assert specificity < 0.5
+
+    def test_specific_feedback_returns_higher(self):
+        """Feedback referencing entity-specific words should score higher."""
+        entity = {
+            "name": "Iron Covenant",
+            "description": "A secretive military order protecting ancient secrets",
+            "goals": ["Protect the archive", "Eliminate memory thieves"],
+        }
+        feedback = (
+            "The Iron Covenant lacks detail about its military structure and "
+            "secretive practices. The archive protection goal needs more specificity."
+        )
+        specificity = compute_feedback_specificity(feedback, entity)
+        assert specificity > 0.0
+
+    def test_returns_rounded(self):
+        """Specificity should be rounded to 4 decimal places."""
+        result = compute_feedback_specificity(
+            "interesting concept", {"name": "Test", "description": "A concept"}
+        )
+        assert result == round(result, 4)
+
+
+class TestComputeSummary:
+    """Tests for compute_summary()."""
+
+    def test_empty_results(self):
+        """Empty results list should produce empty summary dicts."""
+        summary = compute_summary([])
+        assert summary["pass_rate_by_type"] == {}
+
+    def test_single_type_all_pass(self):
+        """All entities passing should give 100% pass rate."""
+        results = [
+            {
+                "entity_type": "faction",
+                "threshold_met": True,
+                "score_progression": [6.5, 7.5, 8.0],
+                "description_diff_ratios": [None, 0.3, 0.2],
+                "feedback_strings": ["Needs work", "Better", "Good"],
+                "feedback_specificity_scores": [0.1, 0.2, 0.3],
+            },
+            {
+                "entity_type": "faction",
+                "threshold_met": True,
+                "score_progression": [7.0, 8.0],
+                "description_diff_ratios": [None, 0.25],
+                "feedback_strings": ["OK", "Great"],
+                "feedback_specificity_scores": [0.15, 0.25],
+            },
+        ]
+        summary = compute_summary(results)
+        assert summary["pass_rate_by_type"]["faction"] == 1.0
+
+    def test_mixed_pass_fail(self):
+        """Mix of pass and fail should give correct pass rate."""
+        results = [
+            {
+                "entity_type": "concept",
+                "threshold_met": True,
+                "score_progression": [7.5],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Good"],
+                "feedback_specificity_scores": [0.2],
+            },
+            {
+                "entity_type": "concept",
+                "threshold_met": False,
+                "score_progression": [6.0, 6.5],
+                "description_diff_ratios": [None, 0.1],
+                "feedback_strings": ["Weak", "Still weak"],
+                "feedback_specificity_scores": [0.1, 0.1],
+            },
+        ]
+        summary = compute_summary(results)
+        assert summary["pass_rate_by_type"]["concept"] == 0.5
+
+    def test_plateau_rate_computation(self):
+        """Score changes below 0.3 should count as plateaus."""
+        results = [
+            {
+                "entity_type": "item",
+                "threshold_met": False,
+                "score_progression": [6.5, 6.5, 6.6],
+                "description_diff_ratios": [None, 0.1, 0.05],
+                "feedback_strings": ["OK", "Same", "Same"],
+                "feedback_specificity_scores": [0.1, 0.1, 0.1],
+            },
+        ]
+        summary = compute_summary(results)
+        # delta[0] = 0.0 (< 0.3 -> plateau), delta[1] = 0.1 (< 0.3 -> plateau)
+        # 2 plateaus out of 2 refinement iterations = 1.0
+        assert summary["plateau_rate"]["item"] == 1.0
+
+    def test_regression_rate_computation(self):
+        """Negative score deltas should count as regressions."""
+        results = [
+            {
+                "entity_type": "location",
+                "threshold_met": False,
+                "score_progression": [7.0, 6.5, 6.0],
+                "description_diff_ratios": [None, 0.3, 0.2],
+                "feedback_strings": ["OK", "Worse", "Bad"],
+                "feedback_specificity_scores": [0.1, 0.1, 0.1],
+            },
+        ]
+        summary = compute_summary(results)
+        assert summary["regression_rate"]["location"] == 1.0
+
+    def test_multiple_types_in_results(self):
+        """Summary should separate metrics per entity type."""
+        results = [
+            {
+                "entity_type": "faction",
+                "threshold_met": True,
+                "score_progression": [8.0],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Great"],
+                "feedback_specificity_scores": [0.3],
+            },
+            {
+                "entity_type": "concept",
+                "threshold_met": False,
+                "score_progression": [5.0],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Weak"],
+                "feedback_specificity_scores": [0.1],
+            },
+        ]
+        summary = compute_summary(results)
+        assert "faction" in summary["pass_rate_by_type"]
+        assert "concept" in summary["pass_rate_by_type"]
+        assert summary["pass_rate_by_type"]["faction"] == 1.0
+        assert summary["pass_rate_by_type"]["concept"] == 0.0
+
+
+class TestStatistics:
+    """Tests for compute_statistics() from judge consistency script."""
+
+    def test_empty_values(self):
+        """Empty list should return zeroed statistics."""
+        stats = compute_statistics([])
+        assert stats["mean"] == 0.0
+        assert stats["std"] == 0.0
+
+    def test_single_value(self):
+        """Single value should return it as mean with zero std."""
+        stats = compute_statistics([7.5])
+        assert stats["mean"] == 7.5
+        assert stats["std"] == 0.0
+        assert stats["cv"] == 0.0
+
+    def test_identical_values(self):
+        """Identical values should have zero std and cv."""
+        stats = compute_statistics([6.0, 6.0, 6.0])
+        assert stats["mean"] == 6.0
+        assert stats["std"] == 0.0
+        assert stats["cv"] == 0.0
+
+    def test_varied_values(self):
+        """Varied values should have non-zero std, correct min/max."""
+        stats = compute_statistics([5.0, 7.0, 9.0])
+        assert stats["mean"] == 7.0
+        assert stats["std"] > 0
+        assert stats["min"] == 5.0
+        assert stats["max"] == 9.0
+        assert stats["cv"] > 0
+
+    def test_cv_computation(self):
+        """CV should be zero when all values are identical."""
+        stats = compute_statistics([10.0, 10.0, 10.0])
+        assert stats["cv"] == 0.0
+
+
+class TestFeedbackSimilarity:
+    """Tests for compute_feedback_similarity()."""
+
+    def test_single_feedback(self):
+        """Single feedback should return perfect similarity."""
+        assert compute_feedback_similarity(["hello"]) == 1.0
+
+    def test_identical_feedbacks(self):
+        """Identical feedback strings should return 1.0."""
+        result = compute_feedback_similarity(["hello world", "hello world"])
+        assert result == 1.0
+
+    def test_completely_different(self):
+        """Completely different word sets should return 0.0."""
+        result = compute_feedback_similarity(["alpha beta gamma", "delta epsilon zeta"])
+        assert result == 0.0
+
+    def test_partially_overlapping(self):
+        """Partially overlapping word sets should return between 0 and 1."""
+        result = compute_feedback_similarity(
+            [
+                "the faction lacks coherence",
+                "the faction needs more distinctiveness",
+            ]
+        )
+        assert 0.0 < result < 1.0
+
+    def test_empty_list(self):
+        """Empty feedback list should return 1.0."""
+        result = compute_feedback_similarity([])
+        assert result == 1.0
+
+
+class TestDetermineVerdict:
+    """Tests for determine_verdict()."""
+
+    def test_consistent_when_low_std(self):
+        """Low std across all dimensions should yield consistent verdict."""
+        per_dim = {
+            "coherence": {"mean": 7.0, "std": 0.1, "min": 6.9, "max": 7.1, "cv": 0.014},
+            "influence": {"mean": 6.5, "std": 0.15, "min": 6.3, "max": 6.7, "cv": 0.023},
+        }
+        assert determine_verdict(per_dim) == "consistent"
+
+    def test_noisy_when_high_std(self):
+        """High std should yield noisy verdict."""
+        per_dim = {
+            "coherence": {"mean": 7.0, "std": 0.8, "min": 5.5, "max": 8.5, "cv": 0.114},
+            "influence": {"mean": 6.5, "std": 0.6, "min": 5.5, "max": 7.5, "cv": 0.092},
+        }
+        assert determine_verdict(per_dim) == "noisy"
+
+    def test_borderline_when_moderate_std(self):
+        """Moderate std should yield borderline verdict."""
+        per_dim = {
+            "coherence": {"mean": 7.0, "std": 0.3, "min": 6.5, "max": 7.5, "cv": 0.043},
+            "influence": {"mean": 6.5, "std": 0.35, "min": 6.0, "max": 7.0, "cv": 0.054},
+        }
+        assert determine_verdict(per_dim) == "borderline"
+
+    def test_empty_dimensions(self):
+        """Empty dimensions dict should default to consistent."""
+        assert determine_verdict({}) == "consistent"
+
+    def test_single_noisy_dimension_makes_noisy(self):
+        """One noisy dimension should make the overall verdict noisy."""
+        per_dim = {
+            "coherence": {"mean": 7.0, "std": 0.1, "min": 6.9, "max": 7.1, "cv": 0.014},
+            "influence": {"mean": 6.5, "std": 0.6, "min": 5.5, "max": 7.5, "cv": 0.092},
+        }
+        assert determine_verdict(per_dim) == "noisy"
+
+
+class TestCanonicalBrief:
+    """Tests for canonical brief and story state creation."""
+
+    def test_make_canonical_brief_has_all_fields(self):
+        """Canonical brief should have all required StoryBrief fields."""
+        brief = make_canonical_brief()
+        assert brief.premise
+        assert brief.genre == "Fantasy"
+        assert len(brief.themes) >= 2
+        assert brief.setting_place
+        assert brief.setting_time
+        assert brief.language == "English"
+
+    def test_make_story_state_wraps_brief(self):
+        """Story state should wrap the brief and use diagnostic ID."""
+        brief = make_canonical_brief()
+        state = make_story_state(brief)
+        assert state.brief is brief
+        assert state.id == "diagnostic-run"
+
+    def test_all_entity_types_list(self):
+        """ALL_ENTITY_TYPES should contain all 6 entity types."""
+        expected = {"character", "faction", "location", "item", "concept", "relationship"}
+        assert set(ALL_ENTITY_TYPES) == expected
+
+    def test_score_dimensions_covers_all_types(self):
+        """Every entity type should have at least 4 score dimensions defined."""
+        for et in ALL_ENTITY_TYPES:
+            assert et in SCORE_DIMENSIONS, f"Missing score dimensions for {et}"
+            assert len(SCORE_DIMENSIONS[et]) >= 4, f"Too few dimensions for {et}"
+
+
+class TestComputeSummaryEdgeCases:
+    """Edge case tests for summary computation."""
+
+    def test_no_refinement_iterations(self):
+        """When all entities pass on first try, refinement metrics should handle gracefully."""
+        results = [
+            {
+                "entity_type": "character",
+                "threshold_met": True,
+                "score_progression": [8.0],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Excellent"],
+                "feedback_specificity_scores": [0.5],
+            },
+        ]
+        summary = compute_summary(results)
+        assert summary["avg_score_improvement_per_iteration"]["character"] == 0.0
+        assert summary["plateau_rate"]["character"] == 0.0
+        assert summary["regression_rate"]["character"] == 0.0
+
+    def test_all_none_diff_ratios(self):
+        """When all diff ratios are None (single iterations), average should be 0."""
+        results = [
+            {
+                "entity_type": "item",
+                "threshold_met": True,
+                "score_progression": [8.0],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Good"],
+                "feedback_specificity_scores": [0.3],
+            },
+        ]
+        summary = compute_summary(results)
+        assert summary["avg_description_diff_ratio"]["item"] == 0.0
+
+
+class TestABPromptConstants:
+    """Tests for A/B prompt script constants and structure."""
+
+    def test_default_ab_types_are_valid(self):
+        """All default A/B types must be in the global entity type list."""
+        for et in DEFAULT_AB_TYPES:
+            assert et in ALL_ENTITY_TYPES, f"{et} not in ALL_ENTITY_TYPES"
+
+    def test_improved_refiners_cover_default_types(self):
+        """Every default A/B type must have an improved refiner function."""
+        for et in DEFAULT_AB_TYPES:
+            assert et in IMPROVED_REFINERS, f"Missing improved refiner for {et}"
+
+    def test_improved_refiners_are_callable(self):
+        """All improved refiners must be callable functions."""
+        for et, func in IMPROVED_REFINERS.items():
+            assert callable(func), f"Refiner for {et} is not callable"
+
+    def test_relationship_excluded_from_ab(self):
+        """Relationship type should not be in A/B defaults (no improved refiner)."""
+        assert "relationship" not in DEFAULT_AB_TYPES
+        assert "relationship" not in IMPROVED_REFINERS
+
+
+class TestStatisticsEdgeCases:
+    """Additional edge case tests for compute_statistics()."""
+
+    def test_two_values_uses_sample_std(self):
+        """With 2 values, should use sample std (n-1 denominator)."""
+        stats = compute_statistics([4.0, 6.0])
+        assert stats["mean"] == 5.0
+        # Sample std of [4, 6] = sqrt(((4-5)^2 + (6-5)^2) / 1) = sqrt(2) ~ 1.414
+        assert abs(stats["std"] - 1.414) < 0.01
+
+    def test_cv_with_zero_mean(self):
+        """Coefficient of variation should be 0 when mean is 0."""
+        stats = compute_statistics([0.0, 0.0])
+        assert stats["cv"] == 0.0
+
+    def test_all_fields_present(self):
+        """Statistics dict should always contain mean, std, min, max, cv."""
+        stats = compute_statistics([3.0, 5.0, 7.0])
+        assert "mean" in stats
+        assert "std" in stats
+        assert "min" in stats
+        assert "max" in stats
+        assert "cv" in stats
+
+    def test_values_are_rounded(self):
+        """Statistics should be rounded to 3 decimal places."""
+        stats = compute_statistics([1.0, 2.0, 3.0])
+        assert stats["mean"] == round(stats["mean"], 3)
+        assert stats["std"] == round(stats["std"], 3)
+        assert stats["cv"] == round(stats["cv"], 3)
+
+
+class TestFeedbackSimilarityEdgeCases:
+    """Additional edge case tests for compute_feedback_similarity()."""
+
+    def test_three_feedbacks_all_identical(self):
+        """Three identical feedbacks should return 1.0."""
+        result = compute_feedback_similarity(
+            ["same words here", "same words here", "same words here"]
+        )
+        assert result == 1.0
+
+    def test_three_feedbacks_mixed(self):
+        """Mixed feedbacks with partial overlap should return intermediate value."""
+        result = compute_feedback_similarity(
+            [
+                "the faction needs coherence",
+                "the faction lacks depth",
+                "completely unrelated words about nothing",
+            ]
+        )
+        assert 0.0 < result < 1.0
+
+    def test_empty_string_feedbacks(self):
+        """Empty strings should be filtered out, returning 1.0."""
+        result = compute_feedback_similarity(["", ""])
+        assert result == 1.0
+
+    def test_result_is_rounded(self):
+        """Similarity result should be rounded to 3 decimal places."""
+        result = compute_feedback_similarity(["alpha beta gamma delta", "alpha beta epsilon zeta"])
+        assert result == round(result, 3)
+
+
+class TestComputeFeedbackSpecificityEdgeCases:
+    """Additional edge case tests for compute_feedback_specificity()."""
+
+    def test_entity_with_list_fields(self):
+        """Specificity should use list fields like goals and values."""
+        entity = {
+            "name": "Test",
+            "description": "A faction",
+            "goals": ["dominate trade", "control ports"],
+            "values": ["loyalty", "discipline"],
+        }
+        feedback = "The faction should clarify its trade domination goals and loyalty values"
+        specificity = compute_feedback_specificity(feedback, entity)
+        assert specificity > 0.0
+
+    def test_all_stop_words_feedback(self):
+        """Feedback with only stop words should return 0.0 after filtering."""
+        entity = {"name": "X", "description": "Y"}
+        feedback = "the a an is are was were be been being"
+        specificity = compute_feedback_specificity(feedback, entity)
+        assert specificity == 0.0
+
+    def test_entity_with_no_matching_fields(self):
+        """When entity has no text-extractable keys, specificity should be 0.0."""
+        entity = {"id": 123, "type": "custom"}
+        feedback = "interesting concept with good potential"
+        specificity = compute_feedback_specificity(feedback, entity)
+        assert specificity == 0.0
+
+
+class TestExtractDescriptionEdgeCases:
+    """Additional edge case tests for extract_description()."""
+
+    def test_relationship_with_missing_fields(self):
+        """Relationship with only partial fields should still work."""
+        data = {"source": "Alice", "description": "Rivals"}
+        result = extract_description(data, "relationship")
+        assert "Alice" in result
+        assert "Rivals" in result
+
+    def test_empty_description(self):
+        """Entity with empty description returns empty string."""
+        assert extract_description({"name": "Test", "description": ""}, "faction") == ""
+
+    def test_non_relationship_ignores_source_target(self):
+        """Non-relationship entities should just return description."""
+        data = {"name": "X", "description": "A place", "source": "should_not_appear"}
+        result = extract_description(data, "location")
+        assert result == "A place"
+        assert "should_not_appear" not in result
+
+
+class TestComputeSummaryMetrics:
+    """Tests for summary metrics beyond pass rate."""
+
+    def test_avg_score_improvement(self):
+        """Average score improvement per iteration should be computed correctly."""
+        results = [
+            {
+                "entity_type": "faction",
+                "threshold_met": True,
+                "score_progression": [5.0, 7.0, 8.0],
+                "description_diff_ratios": [None, 0.3, 0.2],
+                "feedback_strings": ["Bad", "Better", "Good"],
+                "feedback_specificity_scores": [0.1, 0.2, 0.3],
+            },
+        ]
+        summary = compute_summary(results)
+        # Improvements: 7.0-5.0=2.0, 8.0-7.0=1.0. Average = 1.5
+        assert summary["avg_score_improvement_per_iteration"]["faction"] == 1.5
+
+    def test_avg_feedback_length(self):
+        """Average feedback length should count words correctly."""
+        results = [
+            {
+                "entity_type": "item",
+                "threshold_met": True,
+                "score_progression": [7.5],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["one two three four"],
+                "feedback_specificity_scores": [0.2],
+            },
+        ]
+        summary = compute_summary(results)
+        assert summary["avg_feedback_length"]["item"] == 4.0
+
+    def test_avg_description_diff_ratio(self):
+        """Average description diff ratio should skip None values."""
+        results = [
+            {
+                "entity_type": "concept",
+                "threshold_met": False,
+                "score_progression": [5.0, 6.0, 6.5],
+                "description_diff_ratios": [None, 0.4, 0.2],
+                "feedback_strings": ["Bad", "OK", "Better"],
+                "feedback_specificity_scores": [0.1, 0.1, 0.1],
+            },
+        ]
+        summary = compute_summary(results)
+        # Average of [0.4, 0.2] = 0.3
+        assert summary["avg_description_diff_ratio"]["concept"] == 0.3
+
+    def test_avg_feedback_specificity(self):
+        """Average feedback specificity should average across all entities of a type."""
+        results = [
+            {
+                "entity_type": "location",
+                "threshold_met": True,
+                "score_progression": [8.0],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Good"],
+                "feedback_specificity_scores": [0.4],
+            },
+            {
+                "entity_type": "location",
+                "threshold_met": False,
+                "score_progression": [5.0],
+                "description_diff_ratios": [None],
+                "feedback_strings": ["Weak"],
+                "feedback_specificity_scores": [0.2],
+            },
+        ]
+        summary = compute_summary(results)
+        # Average of [0.4, 0.2] = 0.3
+        assert summary["avg_feedback_specificity"]["location"] == 0.3
+
+
+class TestVerdictThresholds:
+    """Tests verifying that verdict thresholds are correctly defined."""
+
+    def test_noisy_threshold_is_greater_than_consistent(self):
+        """Noisy threshold must be greater than consistent threshold."""
+        assert NOISY_STD_THRESHOLD > CONSISTENT_STD_THRESHOLD
+
+    def test_consistent_threshold_is_positive(self):
+        """Consistent threshold must be positive."""
+        assert CONSISTENT_STD_THRESHOLD > 0
+
+    def test_verdict_at_exact_consistent_boundary(self):
+        """At exactly the consistent threshold, verdict should be consistent."""
+        per_dim = {
+            "dim1": {"mean": 7.0, "std": CONSISTENT_STD_THRESHOLD - 0.01},
+        }
+        assert determine_verdict(per_dim) == "consistent"
+
+    def test_verdict_at_exact_noisy_boundary(self):
+        """At exactly the noisy threshold, verdict should be noisy."""
+        per_dim = {
+            "dim1": {"mean": 7.0, "std": NOISY_STD_THRESHOLD + 0.01},
+        }
+        assert determine_verdict(per_dim) == "noisy"


### PR DESCRIPTION
## Summary
- Add three diagnostic scripts to investigate the 71% refinement loop fail rate (Issue #223):
  - `evaluate_judge_consistency.py` — measures judge scoring variance by calling the judge N times on the same frozen entity
  - `evaluate_refinement.py` — runs the full create→judge→refine→judge loop with instrumentation to capture every intermediate state
  - `evaluate_ab_prompts.py` — A/B tests current vs improved refine prompts to determine if prompt changes can fix the issue
- Add 68 unit tests covering all pure-logic functions exported by the scripts
- Fix two bugs found during code review:
  - `NameError` in A/B script when current refiner returns `None` (`scores_a` was referenced before assignment)
  - Undefined `scores` passed to refiner after judge failure in refinement script

## Test plan
- [x] All 68 unit tests pass (`pytest tests/unit/test_refinement_diagnostics.py`)
- [x] Pre-commit hooks pass (ruff, mypy, interrogate, format)
- [x] Pre-push hooks pass (pytest with 100% coverage)
- [ ] Manual: Run `python scripts/evaluate_judge_consistency.py --entity-types faction --judge-calls 2 --verbose` with Ollama running
- [ ] Manual: Run `python scripts/evaluate_refinement.py --entity-types faction --count-per-type 1 --verbose` with Ollama running

🤖 Generated with [Claude Code](https://claude.com/claude-code)