### PR TITLE
fix: comprehensive logging audit (P0+P1+P2)

### DIFF
--- a/src/services/world_quality_service/__init__.py
+++ b/src/services/world_quality_service/__init__.py
@@ -446,7 +446,7 @@ class WorldQualityService:
             self.ENTITY_CREATOR_ROLES.get(entity_type, "writer") if entity_type else "writer"
         )
         model = self._resolve_model_for_role(agent_role)
-        logger.info(
+        logger.debug(
             "Selected creator model '%s' for entity_type=%s (role=%s)",
             model,
             entity_type,
@@ -484,7 +484,7 @@ class WorldQualityService:
                 alternative_found = False
                 for alt_model in alternatives:
                     if alt_model != creator_model:
-                        logger.info(
+                        logger.debug(
                             "Swapping judge model from '%s' to '%s' for entity_type=%s "
                             "to avoid self-judging bias (creator model is '%s')",
                             model,
@@ -510,7 +510,7 @@ class WorldQualityService:
                             entity_type,
                         )
 
-        logger.info(
+        logger.debug(
             "Selected judge model '%s' for entity_type=%s (role=%s)",
             model,
             entity_type,

--- a/src/services/world_quality_service/_chapter_quality.py
+++ b/src/services/world_quality_service/_chapter_quality.py
@@ -36,6 +36,7 @@ def review_chapter_quality(
     Raises:
         WorldGenerationError: If refinement fails after all attempts.
     """
+    logger.debug("Reviewing chapter quality for 'Ch%d: %s'", chapter.number, chapter.title)
     config = svc.get_config()
 
     return quality_refinement_loop(
@@ -96,6 +97,12 @@ def _judge_chapter_quality(
     prompt = _build_chapter_judge_prompt(chapter, genre, plot_summary)
 
     judge_model = svc._get_judge_model(entity_type="chapter")
+    logger.debug(
+        "Judging chapter quality for 'Ch%d: %s' (model=%s)",
+        chapter.number,
+        chapter.title,
+        judge_model,
+    )
     judge_config = svc.get_judge_config()
     multi_call = judge_config.enabled and judge_config.multi_call_enabled
 
@@ -207,6 +214,7 @@ def _refine_chapter_outline(
     Returns:
         Refined Chapter.
     """
+    logger.debug("Refining chapter outline 'Ch%d: %s'", chapter.number, chapter.title)
     brief = story_state.brief
     weak = scores.weak_dimensions(svc.get_config().quality_threshold)
 

--- a/src/services/world_quality_service/_character.py
+++ b/src/services/world_quality_service/_character.py
@@ -140,6 +140,9 @@ def _create_character(
     Returns:
         New Character or None on failure.
     """
+    logger.debug(
+        "Creating character for story %s (existing: %d)", story_state.id, len(existing_names)
+    )
     brief = story_state.brief
     if not brief:
         return None
@@ -307,6 +310,7 @@ def _refine_character(
     Returns:
         Refined Character.
     """
+    logger.debug("Refining character '%s' for story %s", character.name, story_state.id)
     brief = story_state.brief
     threshold = svc.get_config().quality_threshold
 

--- a/src/services/world_quality_service/_common.py
+++ b/src/services/world_quality_service/_common.py
@@ -85,7 +85,7 @@ def judge_with_averaging(
         return judge_fn()
 
     call_count = judge_config.multi_call_count
-    logger.info(
+    logger.debug(
         "Multi-call judge averaging enabled: making %d judge calls",
         call_count,
     )
@@ -196,7 +196,7 @@ def _aggregate_scores(
     # Construct the final score model
     final_scores["feedback"] = combined_feedback
     averaged = score_model_class(**final_scores)
-    logger.info(
+    logger.debug(
         "Averaged %d judge calls: %s (avg=%.2f)",
         len(results),
         {k: f"{v:.1f}" for k, v in final_scores.items() if isinstance(v, float)},

--- a/src/services/world_quality_service/_concept.py
+++ b/src/services/world_quality_service/_concept.py
@@ -79,6 +79,9 @@ def _create_concept(
     temperature: float,
 ) -> dict[str, Any]:
     """Create a new concept using the creator model with structured generation."""
+    logger.debug(
+        "Creating concept for story %s (existing: %d)", story_state.id, len(existing_names)
+    )
     brief = story_state.brief
     if not brief:
         return {}
@@ -231,6 +234,9 @@ def _refine_concept(
     temperature: float,
 ) -> dict[str, Any]:
     """Refine a concept based on quality feedback using structured generation."""
+    logger.debug(
+        "Refining concept '%s' for story %s", concept.get("name", "Unknown"), story_state.id
+    )
     brief = story_state.brief
 
     # Build specific improvement instructions from feedback

--- a/src/services/world_quality_service/_faction.py
+++ b/src/services/world_quality_service/_faction.py
@@ -126,6 +126,9 @@ def _create_faction(
     Raises:
         WorldGenerationError: If faction generation fails due to unrecoverable errors.
     """
+    logger.debug(
+        "Creating faction for story %s (existing: %d)", story_state.id, len(existing_names)
+    )
     brief = story_state.brief
     if not brief:
         return {}
@@ -312,6 +315,9 @@ def _refine_faction(
     temperature: float,
 ) -> dict[str, Any]:
     """Refine a faction based on quality feedback."""
+    logger.debug(
+        "Refining faction '%s' for story %s", faction.get("name", "Unknown"), story_state.id
+    )
     brief = story_state.brief
 
     # Build specific improvement instructions from feedback

--- a/src/services/world_quality_service/_item.py
+++ b/src/services/world_quality_service/_item.py
@@ -79,6 +79,7 @@ def _create_item(
     temperature: float,
 ) -> dict[str, Any]:
     """Create a new item using the creator model with structured generation."""
+    logger.debug("Creating item for story %s (existing: %d)", story_state.id, len(existing_names))
     brief = story_state.brief
     if not brief:
         return {}
@@ -235,6 +236,7 @@ def _refine_item(
     temperature: float,
 ) -> dict[str, Any]:
     """Refine an item based on quality feedback using structured generation."""
+    logger.debug("Refining item '%s' for story %s", item.get("name", "Unknown"), story_state.id)
     brief = story_state.brief
 
     # Build specific improvement instructions from feedback

--- a/src/services/world_quality_service/_location.py
+++ b/src/services/world_quality_service/_location.py
@@ -79,6 +79,9 @@ def _create_location(
     temperature: float,
 ) -> dict[str, Any]:
     """Create a new location using the creator model with structured generation."""
+    logger.debug(
+        "Creating location for story %s (existing: %d)", story_state.id, len(existing_names)
+    )
     brief = story_state.brief
     if not brief:
         return {}
@@ -232,6 +235,9 @@ def _refine_location(
     temperature: float,
 ) -> dict[str, Any]:
     """Refine a location based on quality feedback using structured generation."""
+    logger.debug(
+        "Refining location '%s' for story %s", location.get("name", "Unknown"), story_state.id
+    )
     brief = story_state.brief
 
     # Build specific improvement instructions from feedback

--- a/src/services/world_quality_service/_plot.py
+++ b/src/services/world_quality_service/_plot.py
@@ -36,6 +36,7 @@ def review_plot_quality(
     Raises:
         WorldGenerationError: If refinement fails after all attempts.
     """
+    logger.debug("Reviewing plot quality for story %s", story_state.id)
     config = svc.get_config()
 
     return quality_refinement_loop(
@@ -93,6 +94,7 @@ def _judge_plot_quality(
     prompt = _build_plot_judge_prompt(plot_outline, genre, brief.themes if brief else [])
 
     judge_model = svc._get_judge_model(entity_type="plot")
+    logger.debug("Judging plot quality for story %s (model=%s)", story_state.id, judge_model)
     judge_config = svc.get_judge_config()
     multi_call = judge_config.enabled and judge_config.multi_call_enabled
 
@@ -193,6 +195,7 @@ def _refine_plot(
     Returns:
         Refined PlotOutline.
     """
+    logger.debug("Refining plot outline for story %s", story_state.id)
     brief = story_state.brief
     weak = scores.weak_dimensions(svc.get_config().quality_threshold)
 

--- a/src/services/world_quality_service/_quality_loop.py
+++ b/src/services/world_quality_service/_quality_loop.py
@@ -138,6 +138,13 @@ def quality_refinement_loop(
                 history.peak_score,
                 history.best_iteration,
             )
+            logger.debug(
+                "%s '%s' iteration %d dimension scores: %s",
+                entity_type.capitalize(),
+                get_name(entity),
+                current_iter,
+                {k: f"{v:.1f}" for k, v in scores.to_dict().items() if isinstance(v, float)},
+            )
 
             # Threshold check
             if scores.average >= config.quality_threshold:

--- a/src/services/world_quality_service/_relationship.py
+++ b/src/services/world_quality_service/_relationship.py
@@ -137,6 +137,11 @@ def _create_relationship(
     temperature: float,
 ) -> dict[str, Any]:
     """Create a new relationship using the creator model."""
+    logger.debug(
+        "Creating relationship for story %s (%d entities available)",
+        story_state.id,
+        len(entity_names),
+    )
     brief = story_state.brief
     if not brief:
         return {}
@@ -315,6 +320,12 @@ def _refine_relationship(
     temperature: float,
 ) -> dict[str, Any]:
     """Refine a relationship based on quality feedback."""
+    logger.debug(
+        "Refining relationship '%s' <-> '%s' for story %s",
+        relationship.get("source", "?"),
+        relationship.get("target", "?"),
+        story_state.id,
+    )
     brief = story_state.brief
     threshold = svc.get_config().quality_threshold
 

--- a/tests/unit/test_services/test_world_quality_judge_reliability.py
+++ b/tests/unit/test_services/test_world_quality_judge_reliability.py
@@ -1188,7 +1188,7 @@ class TestJudgePrefersAlternativeModel:
                 "get_models_for_role",
                 return_value=["different-judge:8b", "same-model:8b"],
             ),
-            caplog.at_level(logging.INFO),
+            caplog.at_level(logging.DEBUG),
         ):
             model = service._get_judge_model(entity_type="character")
 


### PR DESCRIPTION
## Summary
- **P0:** Register Instructor `parse:error` and `completion:error` hooks on both client instances (`llm_client.py`, `base.py`) for retry visibility — previously retries were completely silent
- **P0:** Add `logger.warning()` with truncated raw response on all 5 silent-return parse paths in `_validation.py` — previously returned empty results with no trace
- **P0:** Add `logger.debug()` before each raw `svc.client.generate()` call in `_validation.py` to log model, temperature, and context
- **P1:** Add per-dimension score DEBUG log in `_quality_loop.py` after the iteration INFO log, showing `scores.to_dict()` breakdown
- **P2:** Downgrade noisy INFO→DEBUG: model selection logs in `__init__.py`, judge averaging in `_common.py`, structured output pre-call in `base.py`
- Add debug logging to entity create/refine/judge entry points across all 8 entity modules

## Test plan
- [x] `ruff format .` + `ruff check .` — all checks passed
- [x] `pytest tests/unit/test_services/test_world_quality_judge_reliability.py` — 50 passed
- [x] `pytest tests/unit/test_agents/test_base.py` — 57 passed
- [x] Pre-commit hooks passed (ruff, mypy, interrogate, pytest with coverage)
- [x] Updated test assertion to capture at DEBUG level after log downgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)