### PR TITLE
fix: use CharacterCreation model for create/refine to prevent arc_progress data loss

### DIFF
--- a/src/services/world_quality_service/_character.py
+++ b/src/services/world_quality_service/_character.py
@@ -374,10 +374,12 @@ Return ONLY the improved character."""
             temperature=temperature,
         )
         refined = creation.to_character()
-        # Preserve runtime-only fields from the original character — arc data
-        # is populated during the write loop, not during refinement.
+        # Preserve fields not included in the refinement prompt — arc data
+        # is populated during the write loop, and relationships aren't
+        # part of the quality evaluation dimensions.
         refined.arc_progress = character.arc_progress.copy()
         refined.arc_type = character.arc_type
+        refined.relationships = character.relationships.copy()
         return refined
     except Exception as e:
         summary = summarize_llm_error(e)

--- a/tests/unit/test_services/test_world_quality_service.py
+++ b/tests/unit/test_services/test_world_quality_service.py
@@ -848,6 +848,7 @@ class TestRefineCharacter:
             description="A simple description",
             personality_traits=["brave"],
             goals=["save the world"],
+            relationships={"Mary": "ally"},
             arc_notes="Basic arc",
             arc_progress={1: "Ordinary world", 2: "Call to adventure"},
             arc_type="hero_journey",
@@ -866,7 +867,8 @@ class TestRefineCharacter:
         assert refined.name == "John Doe"
         assert "deeper psychology" in refined.description
         assert len(refined.personality_traits) > 1
-        # arc_progress and arc_type should be preserved from original
+        # arc_progress, arc_type, and relationships should be preserved from original
+        assert refined.relationships == {"Mary": "ally"}
         assert refined.arc_progress == {1: "Ordinary world", 2: "Call to adventure"}
         assert refined.arc_type == "hero_journey"
 


### PR DESCRIPTION
## Summary
- Character creation and refinement used the full `Character` model as the LLM response schema, which includes `arc_progress: dict[int, str]`. JSON schemas can't enforce integer-only keys, so the LLM returned descriptive string keys (`"current_stage"`, `"key_events"`) that were silently discarded by the validator — causing data loss and score regression during refinement iterations.
- Switch both `_create_character` and `_refine_character` to use `CharacterCreation` (which excludes `arc_progress` and `arc_type`) as the response model. Refinement now preserves the original character's runtime-only fields after conversion.

Closes #305

## Test plan
- [x] Existing create/refine/review/early-stopping tests updated and passing (479 tests)
- [x] New tests verify `response_model=CharacterCreation` is used for both create and refine
- [x] New test verifies `arc_progress` and `arc_type` are preserved through refinement
- [x] mypy, ruff, testmon, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)