### PR TITLE
investigate: add scoring bias and entity depth analysis scripts (#294)

### DIFF
--- a/scripts/investigate_score_distribution.py
+++ b/scripts/investigate_score_distribution.py
@@ -52,18 +52,18 @@ REFINEMENT_TIME_RE = re.compile(
 
 # "Faction 'The Veilkeepers' iteration 1: score 7.5 (best so far: 7.5 at iteration 1)"
 ITERATION_SCORE_RE = re.compile(
-    r"(\w+) '(.+?)' iteration (\d+): score ([\d.]+) "
+    r"(\w+) '(.+)' iteration (\d+): score ([\d.]+) "
     r"\(best so far: ([\d.]+) at iteration (\d+)\)",
 )
 
 # "Faction 'The Veilkeepers' iteration 1 dimension scores: {'coherence': '8.5', ...}"
 DIMENSION_SCORES_RE = re.compile(
-    r"(\w+) '(.+?)' iteration (\d+) dimension scores: (\{.+\})",
+    r"(\w+) '(.+)' iteration (\d+) dimension scores: (\{.+\})",
 )
 
 # "Faction 'The Veilkeepers' met quality threshold (7.5 >= 7.5)"
 THRESHOLD_MET_RE = re.compile(
-    r"(\w+) '(.+?)' met quality threshold \(([\d.]+) >= ([\d.]+)\)",
+    r"(\w+) '(.+)' met quality threshold \(([\d.]+) >= ([\d.]+)\)",
 )
 
 
@@ -297,6 +297,9 @@ def compute_clustering_metrics(records: list[EntityRecord]) -> dict[str, Any]:
             "score_range": 0.0,
             "std_dev": 0.0,
             "iqr": 0.0,
+            "mean": 0.0,
+            "min": 0.0,
+            "max": 0.0,
         }
 
     # Round to 1 decimal for unique counting (matches log format)

--- a/tests/unit/test_investigate_score_distribution.py
+++ b/tests/unit/test_investigate_score_distribution.py
@@ -265,11 +265,14 @@ class TestComputeClusteringMetrics:
     """Tests for score clustering analysis."""
 
     def test_empty_records(self):
-        """Empty records should return zero metrics."""
+        """Empty records should return zero metrics including mean/min/max."""
         metrics = compute_clustering_metrics([])
         assert metrics["unique_scores"] == 0
         assert metrics["total_scores"] == 0
         assert metrics["score_range"] == 0.0
+        assert metrics["mean"] == 0.0
+        assert metrics["min"] == 0.0
+        assert metrics["max"] == 0.0
 
     def test_single_score(self):
         """Single score — range and std_dev should be 0."""


### PR DESCRIPTION
## Summary

- Add `scripts/investigate_score_distribution.py` — parses quality loop logs to produce score histograms, clustering metrics, per-dimension variance, and generation time vs score correlation
- Add `scripts/investigate_entity_depth.py` — reads SQLite world databases to compare entity content depth (text length, vocabulary diversity, field completeness) across entity types
- Add 81 unit tests covering all parsing, analysis, and edge case scenarios
- Exclude `scripts/` from interrogate docstring coverage (standalone utilities, not core app)

These scripts support the investigation in #294 (judge scoring bias + entity depth imbalance). They are diagnostic-only and do not modify production code.

### How to use

```bash
# After running a world build:
python scripts/investigate_score_distribution.py --verbose
python scripts/investigate_entity_depth.py --verbose

# With JSON output:
python scripts/investigate_score_distribution.py --output output/diagnostics/scores.json
python scripts/investigate_entity_depth.py --output output/diagnostics/depth.json
```

### What the scripts measure

**Score Distribution** (`investigate_score_distribution.py`):
- Score histogram (0.5-wide bins) — visualizes clustering
- Clustering metrics (std_dev, IQR, unique values, modal scores)
- Per-entity-type breakdown (mean score, creation time, threshold met rate)
- Per-dimension variance — does the judge differentiate between dimensions?
- Generation time vs score Pearson correlation — do fast entities score as well as slow ones?

**Entity Depth** (`investigate_entity_depth.py`):
- Average text length and word count per entity type
- Vocabulary diversity (type-token ratio) per entity type
- Field completeness (populated vs expected fields)
- Cross-type comparison with imbalance detection (>2x word count difference)

## Test plan

- [x] 81 unit tests passing (40 for score distribution, 41 for entity depth)
- [x] ruff format + lint clean
- [x] mypy clean
- [x] All pre-commit and pre-push hooks pass
- [ ] Run against actual world build log data to validate parsing
- [ ] Run against actual world databases to validate depth analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)